### PR TITLE
Option to clean a dirty pantheon directory

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -247,6 +247,19 @@ class RoboFile extends Tasks {
     $commitAndDeployConfirm = $this->confirm('Commit changes and deploy?');
     if (!$commitAndDeployConfirm) {
       $this->say('Aborted commit and deploy, you can do it manually');
+
+      // The Pantheon repo is dirty, so check if we want to clean it up before
+      // exit.
+      $cleanupPantheonDirectoryConfirm = $this->confirm("Revert any changes on $pantheonDirectory directory (i.e. `git checkout .`)?");
+      if (!$cleanupPantheonDirectoryConfirm) {
+        // Keep folder as is.
+        return;
+      }
+
+      // We repeat "git clean" twice, as sometimes it seems that a single one
+      // doesn't remove all directories.
+      $this->_exec("cd $pantheonDirectory && git checkout . && git clean -fd && git clean -fd && git status");
+
       return;
     }
 


### PR DESCRIPTION
If we aborted a deploy `ddev robo deploy:pantheon`, we may now ask Robo to clean-up the .pantheon directory

![image](https://user-images.githubusercontent.com/125707/79855011-085ef380-83d3-11ea-9b34-318ef5c74b68.png)
