### PR TITLE
Prevent rewriting development.services.yml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
+            },
+            "file-mapping": {
+                "[web-root]/sites/development.services.yml": false
             }
         },
         "installer-paths": {


### PR DESCRIPTION
Upon `ddev composer install` we should not override an existing `development.services.yml`