### PR TITLE
WIP: DDEV - MySQL to Ramdisk

### DIFF
--- a/.ddev/docker-compose.mariadb.yaml
+++ b/.ddev/docker-compose.mariadb.yaml
@@ -1,0 +1,6 @@
+services:
+  db:
+    volumes:
+    - source: /tmp/ddev/drupal-starter
+      target: /var/lib/mysql
+      type: bind


### PR DESCRIPTION
We lost this tweak that we move MySQL datadir into memory for faster test execution, let's see if it's doable and if we gain something with it or not really.