### PR TITLE
Add Entity View Build plugins

### DIFF
--- a/web/modules/custom/server_general/server_general.module
+++ b/web/modules/custom/server_general/server_general.module
@@ -5,12 +5,17 @@
  * Module file.
  */
 
+use Drupal\server_general\BlockContentViewBuilder;
 use Drupal\server_general\NodeViewBuilder;
 
 /**
  * Implements hook_entity_type_alter().
  */
 function server_general_entity_type_alter(array &$entity_types) {
+  if (!empty($entity_types['block_content'])) {
+    $entity_types['block_content']->setViewBuilderClass(BlockContentViewBuilder::class);
+  }
+
   if (!empty($entity_types['node'])) {
     $entity_types['node']->setViewBuilderClass(NodeViewBuilder::class);
   }

--- a/web/modules/custom/server_general/server_general.services.yml
+++ b/web/modules/custom/server_general/server_general.services.yml
@@ -1,4 +1,4 @@
 services:
-  plugin.manager.flag.linktype:
+  plugin.manager.server_general.entity_view_builder:
     class: Drupal\server_general\EntityViewBuilder\EntityViewBuilderPluginManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']

--- a/web/modules/custom/server_general/server_general.services.yml
+++ b/web/modules/custom/server_general/server_general.services.yml
@@ -1,7 +1,4 @@
 services:
-  server_general.node_view_builder_article:
-    class: Drupal\server_general\NodeViewBuilderArticle
-    arguments: ['@entity_type.manager', '@current_user', '@plugin.manager.block']
-  server_general.node_view_builder_basic_page:
-    class: Drupal\server_general\NodeViewBuilderBasicPage
-    arguments: ['@entity_type.manager', '@current_user', '@plugin.manager.block']
+  plugin.manager.flag.linktype:
+    class: Drupal\server_general\EntityViewBuilder\EntityViewBuilderPluginManager
+    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']

--- a/web/modules/custom/server_general/src/Annotation/EntityViewBuilder.php
+++ b/web/modules/custom/server_general/src/Annotation/EntityViewBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\server_general\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines an EntityViewBuilder annotation object.
+ *
+ * @Annotation
+ */
+class EntityViewBuilder extends Plugin {
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+  /**
+   * The plugin description.
+   *
+   * @var string
+   */
+  public $description;
+
+}

--- a/web/modules/custom/server_general/src/BlockContentViewBuilder.php
+++ b/web/modules/custom/server_general/src/BlockContentViewBuilder.php
@@ -2,10 +2,8 @@
 
 namespace Drupal\server_general;
 
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Render\Element;
 use Drupal\block_content\BlockContentViewBuilder as CoreBlockContentViewBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -15,6 +13,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Overrides the core block view builder class to output nodes in custom style.
  */
 class BlockContentViewBuilder extends CoreBlockContentViewBuilder {
+
+  use EntityViewBuilderTrait;
 
   /**
    * The entity view builder service.
@@ -34,42 +34,10 @@ class BlockContentViewBuilder extends CoreBlockContentViewBuilder {
   }
 
   /**
-   * {@inheritDoc}
-   *
-   * This is a dispatcher method, that decides - according to the node type, to
-   * which specific node type node vie builder service to call.
-   *
-   * @throws \Exception
-   */
-
-  /**
    * {@inheritdoc}
    */
   public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
-    $build = parent::view($entity, $view_mode, $langcode);
-    $bundle = $entity->bundle();
-
-    // Check if we have a plugin to take over the bundle of this entity.
-    $plugin_id = $entity->getEntityTypeId() . '.' . $bundle;
-
-    try {
-      // Check if plugin exists.
-      $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
-    }
-    catch (PluginNotFoundException $e) {
-      // We don't have a plugin.
-      return $build;
-    }
-
-    $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
-
-    // Remove the unneeded stuff from the default build. We would add everything
-    // manually.
-    foreach (Element::children($build) as $key) {
-      unset($build[$key]);
-    }
-
-    return $plugin->build($build, $entity);
+    return $this->doView($entity, $view_mode, $langcode);
   }
 
 }

--- a/web/modules/custom/server_general/src/BlockContentViewBuilder.php
+++ b/web/modules/custom/server_general/src/BlockContentViewBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\server_general;
+
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Render\Element;
+use Drupal\block_content\BlockContentViewBuilder as CoreBlockContentViewBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class BlockViewBuilder.
+ *
+ * Overrides the core block view builder class to output nodes in custom style.
+ */
+class BlockContentViewBuilder extends CoreBlockContentViewBuilder {
+
+  /**
+   * The entity view builder service.
+   *
+   * @var \Drupal\server_general\EntityViewBuilder\EntityViewBuilderPluginManager
+   */
+  protected $entityViewBuilderPluginManager;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    $builder = parent::createInstance($container, $entity_type);
+    $builder->entityViewBuilderPluginManager = $container->get('plugin.manager.server_general.entity_view_builder');
+
+    return $builder;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * This is a dispatcher method, that decides - according to the node type, to
+   * which specific node type node vie builder service to call.
+   *
+   * @throws \Exception
+   */
+
+  /**
+   * {@inheritdoc}
+   */
+  public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
+    $build = parent::view($entity, $view_mode, $langcode);
+    $bundle = $entity->bundle();
+
+    // Check if we have a plugin to take over the bundle of this entity.
+    $plugin_id = $entity->getEntityTypeId() . '.' . $bundle;
+
+    try {
+      // Check if plugin exists.
+      $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
+    }
+    catch (PluginNotFoundException $e) {
+      // We don't have a plugin.
+      return $build;
+    }
+
+    $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
+
+    // Remove the unneeded stuff from the default build. We would add everything
+    // manually.
+    foreach (Element::children($build) as $key) {
+      unset($build[$key]);
+    }
+
+    return $plugin->build($build, $entity);
+  }
+
+}

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
@@ -18,10 +18,12 @@ interface EntityViewBuilderPluginInterface extends ContainerFactoryPluginInterfa
    *   The existing render array.
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity to show.
+   * @param string $view_mode
+   *   The view mode.
    *
    * @return array
    *   The new render array.
    */
-  public function build(array $build, EntityInterface $entity);
+  public function build(array $build, EntityInterface $entity, $view_mode = 'full');
 
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
@@ -19,11 +19,13 @@ interface EntityViewBuilderPluginInterface extends ContainerFactoryPluginInterfa
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity to show.
    * @param string $view_mode
-   *   The view mode.
+   *   The view mode. Defaults to "full".
+   * @param string $langcode
+   *   Optional; The language code.
    *
    * @return array
    *   The new render array.
    */
-  public function build(array $build, EntityInterface $entity, $view_mode = 'full');
+  public function build(array $build, EntityInterface $entity, $view_mode = 'full', $langcode = NULL);
 
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
@@ -26,6 +26,6 @@ interface EntityViewBuilderPluginInterface extends ContainerFactoryPluginInterfa
    * @return array
    *   The new render array.
    */
-  public function build(array $build, EntityInterface $entity, $view_mode = 'full', $langcode = NULL);
+  public function view(array $build, EntityInterface $entity, $view_mode = 'full', $langcode = NULL);
 
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
@@ -10,6 +10,15 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
  */
 interface EntityViewBuilderPluginInterface extends ContainerFactoryPluginInterface, PluginInspectionInterface {
 
+  /**
+   * Build a render array.
+   *
+   * @param array $build
+   *   The existing render array.
+   *
+   * @return array
+   *   The new render array.
+   */
   public function build(array $build);
 
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
@@ -3,6 +3,7 @@
 namespace Drupal\server_general\EntityViewBuilder;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 
 /**
@@ -15,10 +16,12 @@ interface EntityViewBuilderPluginInterface extends ContainerFactoryPluginInterfa
    *
    * @param array $build
    *   The existing render array.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to show.
    *
    * @return array
    *   The new render array.
    */
-  public function build(array $build);
+  public function build(array $build, EntityInterface $entity);
 
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\server_general\EntityViewBuilder;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+
+/**
+ * Class EntityViewBuilderPluginInterface.
+ */
+interface EntityViewBuilderPluginInterface extends ContainerFactoryPluginInterface, PluginInspectionInterface {
+
+  public function build(array $build);
+
+}

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginManager.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginManager.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\server_general\EntityViewBuilder;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Plugin manager for Entity view builder.
+ */
+class ActionLinkPluginManager extends DefaultPluginManager {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/EntityViewBuilder', $namespaces, $module_handler, 'Drupal\server_general\ActionLink\ActionLinkTypePluginInterface', 'Drupal\flag\Annotation\EntityViewBuilder');
+    $this->alterInfo('server_general_entity_view_build_info');
+    $this->setCacheBackend($cache_backend, 'server_general_entity_view_build_plugins');
+  }
+}

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginManager.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginManager.php
@@ -15,7 +15,7 @@ class EntityViewBuilderPluginManager extends DefaultPluginManager {
    * {@inheritdoc}
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/EntityViewBuilder', $namespaces, $module_handler, 'Drupal\server_general\ActionLink\ActionLinkTypePluginInterface', 'Drupal\flag\Annotation\EntityViewBuilder');
+    parent::__construct('Plugin/EntityViewBuilder', $namespaces, $module_handler, 'Drupal\server_general\EntityViewBuilder\EntityViewBuilderPluginInterface', 'Drupal\server_general\Annotation\EntityViewBuilder');
     $this->alterInfo('server_general_entity_view_build_info');
     $this->setCacheBackend($cache_backend, 'server_general_entity_view_build_plugins');
   }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginManager.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/EntityViewBuilderPluginManager.php
@@ -9,7 +9,7 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 /**
  * Plugin manager for Entity view builder.
  */
-class ActionLinkPluginManager extends DefaultPluginManager {
+class EntityViewBuilderPluginManager extends DefaultPluginManager {
 
   /**
    * {@inheritdoc}
@@ -19,4 +19,5 @@ class ActionLinkPluginManager extends DefaultPluginManager {
     $this->alterInfo('server_general_entity_view_build_info');
     $this->setCacheBackend($cache_backend, 'server_general_entity_view_build_plugins');
   }
+
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -82,6 +82,9 @@ abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewB
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function build(array $build) {
     /** @var \Drupal\node\NodeInterface $entity */
     $entity = $build['#node'];

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -88,7 +88,7 @@ abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewB
   /**
    * {@inheritdoc}
    */
-  public function build(array $build, EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
+  public function view(array $build, EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
     $bundle = $entity->bundle();
     $view_mode = $build['#view_mode'];
 

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -3,6 +3,7 @@
 namespace Drupal\server_general\EntityViewBuilder;
 
 use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Session\AccountInterface;
@@ -85,9 +86,7 @@ abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewB
   /**
    * {@inheritdoc}
    */
-  public function build(array $build) {
-    /** @var \Drupal\node\NodeInterface $entity */
-    $entity = $build['#node'];
+  public function build(array $build, EntityInterface $entity) {
     $bundle = $entity->bundle();
     $view_mode = $build['#view_mode'];
 

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -86,7 +86,7 @@ abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewB
   /**
    * {@inheritdoc}
    */
-  public function build(array $build, EntityInterface $entity) {
+  public function build(array $build, EntityInterface $entity, $view_mode = 'full') {
     $bundle = $entity->bundle();
     $view_mode = $build['#view_mode'];
 

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -4,15 +4,17 @@ namespace Drupal\server_general\EntityViewBuilder;
 
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
 use Drupal\server_general\ComponentWrapTrait;
 use Drupal\server_general\TagBuilderTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class NodeViewBuilderAbstract.
  */
-abstract class NodeViewBuilderAbstract implements EntityViewBuilderPluginInterface {
+abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewBuilderPluginInterface {
 
   use ComponentWrapTrait;
   use TagBuilderTrait;
@@ -46,6 +48,12 @@ abstract class NodeViewBuilderAbstract implements EntityViewBuilderPluginInterfa
   /**
    * Abstract constructor.
    *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   The entity type manager service.
    * @param \Drupal\Core\Session\AccountInterface $current_user
@@ -53,10 +61,25 @@ abstract class NodeViewBuilderAbstract implements EntityViewBuilderPluginInterfa
    * @param \Drupal\Core\Block\BlockManagerInterface $block_manager
    *   The block manager.
    */
-  public function __construct(EntityTypeManager $entity_type_manager, AccountInterface $current_user, BlockManagerInterface $block_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManager $entity_type_manager, AccountInterface $current_user, BlockManagerInterface $block_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $current_user;
     $this->blockManager = $block_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('plugin.manager.block')
+    );
   }
 
   public function build(array $build) {

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -88,7 +88,7 @@ abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewB
   /**
    * {@inheritdoc}
    */
-  public function build(array $build, EntityInterface $entity, $view_mode = 'full') {
+  public function build(array $build, EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
     $bundle = $entity->bundle();
     $view_mode = $build['#view_mode'];
 

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -9,6 +9,7 @@ use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
 use Drupal\server_general\ComponentWrapTrait;
+use Drupal\server_general\ProcessedTextBuilderTrait;
 use Drupal\server_general\TagBuilderTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -18,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewBuilderPluginInterface {
 
   use ComponentWrapTrait;
+  use ProcessedTextBuilderTrait;
   use TagBuilderTrait;
 
   /**
@@ -236,53 +238,6 @@ abstract class NodeViewBuilderAbstract extends PluginBase implements EntityViewB
 
     $alt = $entity->get($field_name)[0]->alt ?: '';
     return [$url, $alt];
-  }
-
-  /**
-   * Build the body of node.
-   *
-   * @param \Drupal\node\NodeInterface $entity
-   *   The entity.
-   * @param string $field
-   *   Optional; The name of the field. Defaults to "body".
-   *
-   * @return array
-   *   Render array.
-   */
-  protected function buildBody(NodeInterface $entity, $field = 'body') {
-    $element = $this->buildProcessedText($entity, $field);
-    return $this->wrapComponentWithContainer($element, 'content-body');
-  }
-
-  /**
-   * Build a (processed) text of the content.
-   *
-   * @param \Drupal\node\NodeInterface $entity
-   *   The entity.
-   * @param string $field
-   *   Optional; The name of the field. Defaults to "body".
-   * @param bool $summary_or_trimmed
-   *   Optional; If TRUE then the "summary or trimmed" formatter will be used.
-   *   Defaults to FALSE.
-   *
-   * @return array
-   *   Render array.
-   */
-  protected function buildProcessedText(NodeInterface $entity, $field = 'body', $summary_or_trimmed = FALSE) {
-    if ($entity->get($field)->isEmpty()) {
-      return [];
-    }
-
-    $options = ['label' => 'hidden'];
-
-    if ($summary_or_trimmed) {
-      $options['type'] = 'text_summary_or_trimmed';
-    }
-
-    return [
-      '#theme' => 'server_theme_content__body',
-      '#content' => $entity->get($field)->view($options),
-    ];
   }
 
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilder/NodeViewBuilderAbstract.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\server_general;
+namespace Drupal\server_general\EntityViewBuilder;
 
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Entity\EntityTypeManager;

--- a/web/modules/custom/server_general/src/EntityViewBuilderTrait.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilderTrait.php
@@ -54,7 +54,7 @@ trait EntityViewBuilderTrait {
       unset($build[$key]);
     }
 
-    return $plugin->build($build, $entity, $view_mode, $langcode);
+    return $plugin->view($build, $entity, $view_mode, $langcode);
   }
 
 }

--- a/web/modules/custom/server_general/src/EntityViewBuilderTrait.php
+++ b/web/modules/custom/server_general/src/EntityViewBuilderTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\server_general;
+
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Render\Element;
+
+/**
+ * Trait EntityViewBuilderTrait.
+ *
+ * Helper method for dispatching the `view` function.
+ */
+trait EntityViewBuilderTrait {
+
+  /**
+   * Call View Builder plugin, if exists, to get the correct render array.
+   *
+   * This is a dispatcher method, that decides - according to the entity type,
+   * and bundle to which plugin to call, in order to get a render array.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   * @param string $view_mode
+   *   The view mode. Defaults to "full".
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function doView(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
+    $build = parent::view($entity, $view_mode, $langcode);
+    $bundle = $entity->bundle();
+
+    // Check if we have a plugin to take over the bundle of this entity.
+    $plugin_id = $entity->getEntityTypeId() . '.' . $bundle;
+
+    try {
+      // Check if the plugin exists.
+      $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
+    }
+    catch (PluginNotFoundException $e) {
+      // We don't have a plugin.
+      return $build;
+    }
+
+    /** @var \Drupal\server_general\EntityViewBuilder\EntityViewBuilderPluginInterface $plugin */
+    $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
+
+    // Remove the unneeded stuff from the default build. We would add everything
+    // manually.
+    foreach (Element::children($build) as $key) {
+      unset($build[$key]);
+    }
+
+    return $plugin->build($build, $entity, $view_mode, $langcode);
+  }
+
+}

--- a/web/modules/custom/server_general/src/NodeViewBuilder.php
+++ b/web/modules/custom/server_general/src/NodeViewBuilder.php
@@ -58,7 +58,7 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
       return $build;
     }
 
-    $plugin = $plugin_definition->getPlugin();
+    $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
 
     $view_mode = $build['#view_mode'];
 

--- a/web/modules/custom/server_general/src/NodeViewBuilder.php
+++ b/web/modules/custom/server_general/src/NodeViewBuilder.php
@@ -15,33 +15,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class NodeViewBuilder extends CoreNodeViewBuilder {
 
   /**
-   * The node view builder for Article node type.
-   *
-   * @var \Drupal\server_general\NodeViewBuilderArticle
-   */
-  protected $nodeViewBuilderArticle;
-
-  /**
-   * The node view builder for Basic page node type.
-   *
-   * @var \Drupal\server_general\NodeViewBuilderBasicPage
-   */
-  protected $nodeViewBuilderBasicPage;
-
-  /**
-   * The block manager.
-   *
-   * @var \Drupal\Core\Block\BlockManagerInterface
-   */
-  protected $blockManager;
-
-  /**
    * {@inheritDoc}
    */
   public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
     $builder = parent::createInstance($container, $entity_type);
-    $builder->nodeViewBuilderArticle = $container->get('server_general.node_view_builder_article');
-    $builder->nodeViewBuilderBasicPage = $container->get('server_general.node_view_builder_basic_page');
 
     return $builder;
   }

--- a/web/modules/custom/server_general/src/NodeViewBuilder.php
+++ b/web/modules/custom/server_general/src/NodeViewBuilder.php
@@ -60,22 +60,13 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
     }
 
     $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
-    $view_mode = $build['#view_mode'];
-
-    // We should get a method name such as `buildFull`, and `buildTeaser`.
-    $method = 'build' . mb_convert_case($view_mode, MB_CASE_TITLE);
-    $method = str_replace(['_', '-', ' '], '', $method);
-
-    if (!is_callable([$plugin, $method])) {
-      throw new \Exception("The node view builder method `$method` for bundle $bundle and view mode $view_mode not found");
-    }
 
     // Remove the unneeded stuff from the default build.
     foreach (Element::children($build) as $key) {
       unset($build[$key]);
     }
 
-    return $plugin->$method($build, $entity);
+    return $plugin->build($build, $entity);
   }
 
 }

--- a/web/modules/custom/server_general/src/NodeViewBuilder.php
+++ b/web/modules/custom/server_general/src/NodeViewBuilder.php
@@ -51,7 +51,8 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
     $plugin_id = $entity->getEntityTypeId() . '.' . $bundle;
 
     try {
-      $plugin_definition = $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
+      // Check if plugin exists.
+      $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
     }
     catch (PluginNotFoundException $e) {
       // We don't have a plugin.
@@ -59,7 +60,6 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
     }
 
     $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
-
     $view_mode = $build['#view_mode'];
 
     // We should get a method name such as `buildFull`, and `buildTeaser`.

--- a/web/modules/custom/server_general/src/NodeViewBuilder.php
+++ b/web/modules/custom/server_general/src/NodeViewBuilder.php
@@ -3,6 +3,7 @@
 namespace Drupal\server_general;
 
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Render\Element;
 use Drupal\node\NodeViewBuilder as CoreNodeViewBuilder;
@@ -40,11 +41,8 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
    *
    * @throws \Exception
    */
-  public function build(array $build) {
-    $build = parent::build($build);
-
-    /** @var \Drupal\node\NodeInterface $entity */
-    $entity = $build['#node'];
+  public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
+    $build = parent::view($entity, $view_mode, $langcode);
     $bundle = $entity->bundle();
 
     // Check if we have a plugin to take over the bundle of this entity.
@@ -61,7 +59,8 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
 
     $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
 
-    // Remove the unneeded stuff from the default build.
+    // Remove the unneeded stuff from the default build. We would add everything
+    // manually.
     foreach (Element::children($build) as $key) {
       unset($build[$key]);
     }

--- a/web/modules/custom/server_general/src/NodeViewBuilder.php
+++ b/web/modules/custom/server_general/src/NodeViewBuilder.php
@@ -2,10 +2,8 @@
 
 namespace Drupal\server_general;
 
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Render\Element;
 use Drupal\node\NodeViewBuilder as CoreNodeViewBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -15,6 +13,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Overrides the core node view builder class to output nodes in custom style.
  */
 class NodeViewBuilder extends CoreNodeViewBuilder {
+
+  use EntityViewBuilderTrait;
 
   /**
    * The entity view builder service.
@@ -42,30 +42,7 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
    * @throws \Exception
    */
   public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
-    $build = parent::view($entity, $view_mode, $langcode);
-    $bundle = $entity->bundle();
-
-    // Check if we have a plugin to take over the bundle of this entity.
-    $plugin_id = $entity->getEntityTypeId() . '.' . $bundle;
-
-    try {
-      // Check if plugin exists.
-      $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
-    }
-    catch (PluginNotFoundException $e) {
-      // We don't have a plugin.
-      return $build;
-    }
-
-    $plugin = $this->entityViewBuilderPluginManager->createInstance($plugin_id);
-
-    // Remove the unneeded stuff from the default build. We would add everything
-    // manually.
-    foreach (Element::children($build) as $key) {
-      unset($build[$key]);
-    }
-
-    return $plugin->build($build, $entity);
+    return $this->doView($entity, $view_mode, $langcode);
   }
 
 }

--- a/web/modules/custom/server_general/src/NodeViewBuilder.php
+++ b/web/modules/custom/server_general/src/NodeViewBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\server_general;
 
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Render\Element;
 use Drupal\node\NodeViewBuilder as CoreNodeViewBuilder;
@@ -48,9 +49,11 @@ class NodeViewBuilder extends CoreNodeViewBuilder {
 
     // Check if we have a plugin to take over the bundle of this entity.
     $plugin_id = $entity->getEntityTypeId() . '.' . $bundle;
-    $plugin_definition = $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
 
-    if (!$plugin_definition) {
+    try {
+      $plugin_definition = $this->entityViewBuilderPluginManager->getDefinition($plugin_id);
+    }
+    catch (PluginNotFoundException $e) {
       // We don't have a plugin.
       return $build;
     }

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\server_general\ComponentWrapTrait;
 use Drupal\server_general\EntityViewBuilder\EntityViewBuilderPluginInterface;
+use Drupal\server_general\ProcessedTextBuilderTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -20,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class BlockBasic extends PluginBase implements EntityViewBuilderPluginInterface {
 
   use ComponentWrapTrait;
+  use ProcessedTextBuilderTrait;
 
   /**
    * {@inheritdoc}
@@ -36,9 +38,45 @@ class BlockBasic extends PluginBase implements EntityViewBuilderPluginInterface 
    * {@inheritdoc}
    */
   public function build(array $build, EntityInterface $entity, $view_mode = 'full') {
-    $build['extra'] = ['#markup' => $this->t('This is coming from \Drupal\server_general\Plugin\EntityViewBuilder\BlockBasic')];
+    $build['title'] = $this->buildTitle($entity);
+    dump($build['title']);
+    $build['body'] = $this->buildBody($entity);
+    $build['extra'] = $this->buildExtra();
 
-    return $this->wrapComponentWithContainer($build, 'block-wrapper');
+    return $build;
+  }
+
+  /**
+   * Get the Block's title.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function buildTitle(EntityInterface $entity) {
+    $element = [
+      '#type' => 'html_tag',
+      '#tag' => 'h2',
+      '#value' => $entity->label(),
+    ];
+
+    return $this->wrapComponentWithContainer($element, 'title-wrapper');
+  }
+
+  /**
+   * Get Extra info to add to the Block.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function buildExtra() {
+    $element = [
+      '#markup' => $this->t('This is coming from \Drupal\server_general\Plugin\EntityViewBuilder\BlockBasic'),
+    ];
+
+    return $this->wrapComponentWithContainer($element, 'extra-wrapper');
   }
 
 }

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
@@ -37,7 +37,7 @@ class BlockBasic extends PluginBase implements EntityViewBuilderPluginInterface 
   /**
    * {@inheritdoc}
    */
-  public function build(array $build, EntityInterface $entity, $view_mode = 'full') {
+  public function view(array $build, EntityInterface $entity, $view_mode = 'full') {
     $build['title'] = $this->buildTitle($entity);
     $build['body'] = $this->buildBody($entity);
     $build['extra'] = $this->buildExtra();

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
@@ -39,7 +39,6 @@ class BlockBasic extends PluginBase implements EntityViewBuilderPluginInterface 
    */
   public function build(array $build, EntityInterface $entity, $view_mode = 'full') {
     $build['title'] = $this->buildTitle($entity);
-    dump($build['title']);
     $build['body'] = $this->buildBody($entity);
     $build['extra'] = $this->buildExtra();
 

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/BlockBasic.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\server_general\Plugin\EntityViewBuilder;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\server_general\ComponentWrapTrait;
+use Drupal\server_general\EntityViewBuilder\EntityViewBuilderPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class BlockBasic.
+ *
+ * @EntityViewBuilder(
+ *   id = "block_content.basic",
+ *   label = @Translation("Block content - Basic"),
+ *   description = "Block content view builder for Basic bundle."
+ * )
+ */
+class BlockBasic extends PluginBase implements EntityViewBuilderPluginInterface {
+
+  use ComponentWrapTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(array $build, EntityInterface $entity, $view_mode = 'full') {
+    $build['extra'] = ['#markup' => $this->t('This is coming from \Drupal\server_general\Plugin\EntityViewBuilder\BlockBasic')];
+
+    return $this->wrapComponentWithContainer($build, 'block-wrapper');
+  }
+
+}

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
@@ -3,6 +3,7 @@
 namespace Drupal\server_general;
 
 use Drupal\node\NodeInterface;
+use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
 
 /**
  * Class NodeViewBuilderArticle.

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\server_general;
+namespace Drupal\server_general\Plugin\EntityViewBuilder;
 
 use Drupal\node\NodeInterface;
 use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
@@ -7,6 +7,12 @@ use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
 
 /**
  * Class NodeArticle.
+ *
+ * @EntityViewBuilder(
+ *   id = "node.article",
+ *   label = @Translation("Node - Article"),
+ *   description = "Node view builder for Article bundle."
+ * )
  */
 class NodeArticle extends NodeViewBuilderAbstract {
 

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeArticle.php
@@ -6,9 +6,9 @@ use Drupal\node\NodeInterface;
 use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
 
 /**
- * Class NodeViewBuilderArticle.
+ * Class NodeArticle.
  */
-class NodeViewBuilderArticle extends NodeViewBuilderAbstract {
+class NodeArticle extends NodeViewBuilderAbstract {
 
   /**
    * Build full view mode.

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
@@ -7,6 +7,12 @@ use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
 
 /**
  * Class NodeBasicPage.
+ *
+ * @EntityViewBuilder(
+ *   id = "node.page",
+ *   label = @Translation("Node - Basic page"),
+ *   description = "Node view builder for Basic page bundle."
+ * )
  */
 class NodeBasicPage extends NodeViewBuilderAbstract {
 

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
@@ -6,9 +6,9 @@ use Drupal\node\NodeInterface;
 use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
 
 /**
- * Class NodeViewBuilderBasicPage.
+ * Class NodeBasicPage.
  */
-class NodeViewBuilderBasicPage extends NodeViewBuilderAbstract {
+class NodeBasicPage extends NodeViewBuilderAbstract {
 
   /**
    * Build "Basic Page" in "Full" view mode.

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
@@ -3,6 +3,7 @@
 namespace Drupal\server_general;
 
 use Drupal\node\NodeInterface;
+use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;
 
 /**
  * Class NodeViewBuilderBasicPage.

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeBasicPage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\server_general;
+namespace Drupal\server_general\Plugin\EntityViewBuilder;
 
 use Drupal\node\NodeInterface;
 use Drupal\server_general\EntityViewBuilder\NodeViewBuilderAbstract;

--- a/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
+++ b/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\server_general;
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Trait ProcessedTextBuilderTrait.
+ *
+ * Helper method for building a Processed text (e.g. a body field).
+ */
+trait ProcessedTextBuilderTrait {
+
+  /**
+   * Build the body of node.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   * @param string $field
+   *   Optional; The name of the field. Defaults to "body".
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function buildBody(EntityInterface $entity, $field = 'body') {
+    $element = $this->buildProcessedText($entity, $field);
+    return $this->wrapComponentWithContainer($element, 'content-body');
+  }
+
+  /**
+   * Build a (processed) text of the content.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   * @param string $field
+   *   Optional; The name of the field. Defaults to "body".
+   * @param bool $summary_or_trimmed
+   *   Optional; If TRUE then the "summary or trimmed" formatter will be used.
+   *   Defaults to FALSE.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function buildProcessedText(EntityInterface $entity, $field = 'body', $summary_or_trimmed = FALSE) {
+    if ($entity->get($field)->isEmpty()) {
+      return [];
+    }
+
+    $options = ['label' => 'hidden'];
+
+    if ($summary_or_trimmed) {
+      $options['type'] = 'text_summary_or_trimmed';
+    }
+
+    return [
+      '#theme' => 'server_theme_content__body',
+      '#content' => $entity->get($field)->view($options),
+    ];
+  }
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralExampleTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralExampleTest.php
@@ -17,7 +17,7 @@ class ServerGeneralExampleTest extends ExistingSiteBase {
    * @throws \Drupal\Core\Entity\EntityMalformedException
    * @throws \Behat\Mink\Exception\ExpectationException
    */
-  public function testLlama() {
+  public function testArticle() {
     // Creates a user. Will be automatically cleaned up at the end of the test.
     $author = $this->createUser([], NULL, TRUE);
 

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralExampleTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralExampleTest.php
@@ -19,7 +19,7 @@ class ServerGeneralExampleTest extends ExistingSiteBase {
    */
   public function testArticle() {
     // Creates a user. Will be automatically cleaned up at the end of the test.
-    $author = $this->createUser([], NULL, TRUE);
+    $author = $this->createUser();
 
     // Create a taxonomy term. Will be automatically cleaned up at the end of
     // the test.
@@ -36,7 +36,6 @@ class ServerGeneralExampleTest extends ExistingSiteBase {
       ],
       'uid' => $author->id(),
     ]);
-    $node->setPublished()->save();
     $this->assertEquals($author->id(), $node->getOwnerId());
 
     // We can browse pages.


### PR DESCRIPTION
Instead of services to hijack an entity view, we'll use Plugins.

Outcome remains the same

![image](https://user-images.githubusercontent.com/125707/89730702-d046f380-da49-11ea-90b6-a835f354f7c9.png)

However, we have less wiring to do every-time we'd like to add another Plugin. Just write the class - and we'd send it to the plugin if it exists. Otherwise, we'll return the original build.

/cc @bboro 