### PR TITLE
Update running workflows filter when deploying to pantheon

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -286,7 +286,7 @@ class RoboFile extends Tasks {
     usleep(self::DEPLOYMENT_WAIT_TIME);
     $pantheon_env = $branch_name == 'master' ? 'dev' : $branch_name;
     do {
-      $code_sync_completed = $this->_exec("terminus workflow:list " . self::PANTHEON_NAME . " --format=csv | grep " . $pantheon_env . " | grep Sync | grep -v succeeded")->getExitCode();
+      $code_sync_completed = $this->_exec("terminus workflow:list " . self::PANTHEON_NAME . " --format=csv | grep " . $pantheon_env . " | grep Sync | awk -F',' '{print $5}' | grep running")->getExitCode();
       usleep(self::DEPLOYMENT_WAIT_TIME);
     } while (!$code_sync_completed);
     $this->deployPantheonSync($pantheon_env, FALSE);


### PR DESCRIPTION
If a job has failed, `grep -v succeeded` picks it up, so the deploys never finish as the `do while` loop [runs for 2 hours](https://travis-ci.com/github/Gizra/jep-portal/builds/181611694). 

This should specifically look for `Sync` jobs with `running` status, and if none left, then it should continue the rest of the deploy.

Here's a successful build when the fix was applied https://travis-ci.com/github/Gizra/jep-portal/builds/181643886