### PR TITLE
Add a robo command to reinstall an environment on Pantheon.

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -338,10 +338,8 @@ class RoboFile extends Tasks {
   /**
    * Reinstall the site on specific env on Pantheon.
    *
-   * Running this command via `ddev` will require terminus login inside ddev.
-   * Instead, it's possible to run the command locally, where usually already
-   * authenticated to `terminus`:
-   * - `./vendor/consolidation/robo/robo reinstall:env`
+   * Running this command via `ddev` will require terminus login inside ddev:
+   * `ddev auth ssh`
    *
    * @param string $env
    *   The environment to reinstall (default='qa').

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -336,6 +336,58 @@ class RoboFile extends Tasks {
   }
 
   /**
+   * Reinstall the site on specific env on Pantheon.
+   *
+   * Running this command via `ddev` will require terminus login inside ddev.
+   * Instead, it's possible to run the command locally, where usually already
+   * authenticated to `terminus`:
+   * - `./vendor/consolidation/robo/robo reinstall:env`
+   *
+   * @param string $env
+   *   The environment to reinstall (default='qa').
+   *
+   * @throws \Robo\Exception\TaskException
+   */
+  public function reinstallEnv(string $env = 'qa') {
+    $forbidden_envs = [
+      'live',
+    ];
+    if (in_array($env, $forbidden_envs)) {
+      throw new Exception("Reinstalling the site on `{$env}` environment is forbidden.");
+    }
+
+    $pantheon_name = self::PANTHEON_NAME;
+    $pantheon_terminus_environment = $pantheon_name . '.' . $env;
+
+    // This set of commands should work, so expecting no failures.
+    // (tend to invoke the same flow as DDEV's `config.local.yaml`.
+    $task = $this
+      ->taskExecStack()
+      ->stopOnFail();
+
+    $result = $task
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- si server -y --existing-config")
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- en server_migrate -y")
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- migrate:import --group=server")
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- pm:uninstall server_migrate")
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- uli")
+      ->run()
+      ->getExitCode();
+
+    // For these environments, set the `admin` user's password to `1234`.
+    $envs_to_set_admin_simple_password = [
+      'qa'
+    ];
+    if (in_array($env, $envs_to_set_admin_simple_password)) {
+      $task->exec("terminus remote:drush $pantheon_terminus_environment -- user:password admin 1234")->run();
+    }
+
+    if ($result !== 0) {
+      throw new Exception("The site failed to get reinstalled on Pantheon's `{$env}` environment.");
+    }
+  }
+
+  /**
    * Perform a Code sniffer test, and fix when applicable.
    */
   public function phpcs() {


### PR DESCRIPTION
Reinstalling an environment on Pantheon requires running multiple commands.
Instead of running them manually each time, it's better to have a script to do it.