### PR TITLE
Make imagemin tools available inside DDEV

### DIFF
--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -2,4 +2,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 RUN apt-get update
+# For being able to optimize images as part of theme compilation, we install
+# extra tools here - in a non-interactive way, also trying to avoid extra
+# packages that would increase the image size.
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests optipng jpegoptim

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -1,0 +1,5 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests optipng jpegoptim


### PR DESCRIPTION
In a client project, I faced with this at an almost fresh fork of the Drupal Starter:

```
 [Assets\ImageMinify] Minifying /var/www/html/web/themes/custom/server_theme/src/images/no-photo.png with optipng
 [warning] printed() is deprecated. Please use printOutput().
 [Exec] Running optipng -quiet -out "web/themes/custom/server_theme/dist/images/no-photo.png" -- "/var/www/html/web/themes/custom/server_theme/src/images/no-photo.png"
 [Exec]    Time 0.002s
 [Exec]  Exit code 127  Time 0.002s
 [Assets\ImageMinify]  The optipng executable cannot be found 
```