### PR TITLE
Fix svg compress error and working directory

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -109,7 +109,7 @@ class RoboFile extends Tasks {
         ->run();
 
       // Compress all SVGs.
-      $this->themeCompressSvg();
+      $this->themeSvgCompress();
     }
 
     $this->_exec('drush cache:rebuild');
@@ -349,7 +349,7 @@ class RoboFile extends Tasks {
    * This function is being called as part of `theme:compile`.
    * @see compileTheme_()
    */
-  public function themeCompressSvg() {
+  public function themeSvgCompress() {
     $directories = [
       './dist/images',
     ];
@@ -359,7 +359,11 @@ class RoboFile extends Tasks {
     foreach ($directories as $directory) {
       // Check if SVG files exists in this directory.
       $finder = new Finder();
-      $finder->in('web/themes/custom/server_theme/' . $directory);
+      $finder
+        ->in('web/themes/custom/server_theme/' . $directory)
+        ->files()
+        ->name('*.svg');
+
       if (!$finder->hasResults()) {
         // No SVG files.
         continue;

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -4,6 +4,7 @@ use ScssPhp\ScssPhp\Compiler;
 use Lurker\Event\FilesystemEvent;
 use Robo\Tasks;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -350,13 +351,21 @@ class RoboFile extends Tasks {
    */
   public function themeCompressSvg() {
     $directories = [
-      './src/images/*.svg',
+      './src/images',
     ];
 
     $error_code = NULL;
 
     foreach ($directories as $directory) {
-      $result = $this->_exec("cd web/themes/custom/server_theme && ./node_modules/svgo/bin/svgo $directory");
+      // Check if SVG files exists in this directory.
+      $finder = new Finder();
+      $finder->in('web/themes/custom/server_theme/' . $directory);
+      if (!$finder->hasResults()) {
+        // No SVG files.
+        continue;
+      }
+
+      $result = $this->_exec("cd web/themes/custom/server_theme && ./node_modules/svgo/bin/svgo $directory/*.svg");
       if (empty($error_code) && !$result->wasSuccessful()) {
         $error_code = $result->getExitCode();
       }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -36,9 +36,6 @@ class RoboFile extends Tasks {
    *   Indicate whether to optimize during compilation.
    */
   private function compileTheme_($optimize = FALSE) {
-    // Compress all SVGs.
-    $this->themeCompressSvg();
-
     // Notice we don't cleanup the `dist/css` as we'd want parcel, which
     // bundles TailWind and Sass to keep using its cache - for faster builds.
     // We also don't deal with the "fonts" directory, as Parcel already copies
@@ -110,6 +107,9 @@ class RoboFile extends Tasks {
       $this->taskImageMinify($input)
         ->to(self::THEME_BASE . '/dist/images/')
         ->run();
+
+      // Compress all SVGs.
+      $this->themeCompressSvg();
     }
 
     $this->_exec('drush cache:rebuild');
@@ -344,14 +344,14 @@ class RoboFile extends Tasks {
   }
 
   /**
-   * Compress SVG files in specific directories.
+   * Compress SVG files in the "dist" directories.
    *
    * This function is being called as part of `theme:compile`.
    * @see compileTheme_()
    */
   public function themeCompressSvg() {
     $directories = [
-      './src/images',
+      './dist/images',
     ];
 
     $error_code = NULL;


### PR DESCRIPTION
* PR prevents this error when no SVG file exists

![image](https://user-images.githubusercontent.com/125707/99646133-c5dcc280-2a58-11eb-9639-873a09de76e7.png)

* We perform the optimization on the `dist` directory instead of directly on the `src`