### PR TITLE
Remove the cache clears before a database update

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -326,15 +326,12 @@ class RoboFile extends Tasks {
     }
 
     $result = $task
-      ->exec("terminus remote:drush $pantheon_terminus_environment -- cr")
-
-      // A second cache-clear, because Drupal...
-      ->exec("terminus remote:drush $pantheon_terminus_environment -- cr")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- updb -y")
-
-      // A second config import, because Drupal...
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- cr")
+      // A second config import may be needed so run twice.
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cim -y")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cim -y")
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- cr")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- uli")
       ->run()
       ->getExitCode();


### PR DESCRIPTION
Context:

> When an already enabled module, such as server_general, creates a dependency on a new module which is not yet installed, we get an error while deploying and get stuck with a dead env. Not even a cache clear works. In these cases, we must follow the official docs on how to perform such an update to a module, documented in this change record: https://www.drupal.org/node/3067480 specifically: create a hook_update_N implementation to enable the new dependency module in there.
> 
> But this does not work for our deploys, since there's a 'cr' in front of the updb which prevents the hook_update_N to run because the cr always fails.