### PR TITLE
Different containers in styleguide

### DIFF
--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -72,6 +72,53 @@ class StyleGuideController extends ControllerBase {
    *   A simple renderable array.
    */
   public function styleGuidePage() {
+    // Initialize the page build render array.
+    $build = [];
+    // Add the full width elements to the build.
+    $build['full_width_elements'] = $this->getFullWidthElements();
+    // Add the elements wrapped in wide container to the build.
+    $build['wide_width_elements'] = $this->getWideWidthElements();
+    // Add the elements wrapped in narrow container to the build.
+    $build['narrow_width_elements'] = $this->getNarrowWidthElements();
+    return $build;
+  }
+
+  /**
+   * Define all elements here that should be 'full' width.
+   *
+   * Elements spanning full-width of the document.
+   *
+   * @return array
+   *   A render array containing the elements.
+   */
+  protected function getFullWidthElements() {
+    $build[] = [
+      '#markup' => $this->getComponentPrefix('Full width elements'),
+    ];
+
+    $element['server_theme_footer'] = [
+      '#prefix' => $this->getComponentPrefix('Footer'),
+      '#theme' => 'server_theme_footer',
+    ];
+
+    // Add container around each element.
+    foreach ($element as $value) {
+      $build[] = $this->wrapComponentWithContainer($value, 'styleguide-full-width-elements', 'fluid-container-full');
+    }
+
+    return $build;
+  }
+
+  /**
+   * Define all elements here that should be 'wide' width.
+   *
+   * @return array
+   *   A render array containing the elements.
+   */
+  protected function getWideWidthElements() {
+    $build[] = [
+      '#markup' => $this->getComponentPrefix('Wide width elements'),
+    ];
     $card_image = $this->getPlaceholderImage(600, 520);
 
     $tags = [
@@ -214,15 +261,29 @@ class StyleGuideController extends ControllerBase {
       '#rows' => $table_rows,
     ];
 
-    $element['server_theme_footer'] = [
-      '#prefix' => $this->getComponentPrefix('Footer'),
-      '#theme' => 'server_theme_footer',
-    ];
-
     $element['server_theme_page_title'] = [
       '#prefix' => $this->getComponentPrefix('Page Title'),
       '#theme' => 'server_theme_page_title',
       '#title' => 'The source has extend, but not everyone fears it',
+    ];
+
+    // Add container around each element.
+    foreach ($element as $value) {
+      $build[] = $this->wrapComponentWithContainer($value, 'styleguide-wide-width-elements', 'fluid-container-wide');
+    }
+
+    return $build;
+  }
+
+  /**
+   * Define all elements here that should be 'narrow' width.
+   *
+   * @return array
+   *   A render array containing the elements.
+   */
+  protected function getNarrowWidthElements() {
+    $build[] = [
+      '#markup' => $this->getComponentPrefix('Narrow width elements'),
     ];
 
     $element['server_theme_user_image__photo'] = [
@@ -241,9 +302,8 @@ class StyleGuideController extends ControllerBase {
     ];
 
     // Add container around each element.
-    $build = [];
     foreach ($element as $value) {
-      $build[] = $this->wrapComponentWithContainer($value, '', 'fluid-container-wide');
+      $build[] = $this->wrapComponentWithContainer($value, 'styleguide-narrow-width-elements', 'fluid-container-narrow');
     }
 
     return $build;

--- a/web/themes/custom/server_theme/src/scss/components/container.pcss
+++ b/web/themes/custom/server_theme/src/scss/components/container.pcss
@@ -1,0 +1,13 @@
+.fluid-container {
+  &-full {
+    @apply max-w-full;
+  }
+
+  &-wide {
+    @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
+  }
+
+  &-narrow {
+    @apply max-w-6xl mx-auto px-4 sm:px-6 lg:px-8;
+  }
+}

--- a/web/themes/custom/server_theme/src/scss/components/typography.pcss
+++ b/web/themes/custom/server_theme/src/scss/components/typography.pcss
@@ -1,11 +1,3 @@
 h1, h2, h3, h4 {
   @apply font-headers leading-none text-gray-700;
 }
-
-.fluid-container-wide {
-  @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
-}
-
-.fluid-container-narrow {
-  @apply max-w-6xl mx-auto px-4 sm:px-6 lg:px-8;
-}

--- a/web/themes/custom/server_theme/src/scss/style.pcss
+++ b/web/themes/custom/server_theme/src/scss/style.pcss
@@ -1,6 +1,7 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 
+@import "components/container.pcss";
 @import "components/typography.pcss";
 @import "components/list.pcss";
 

--- a/web/themes/custom/server_theme/templates/server-theme-footer.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-footer.html.twig
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 <footer class="bg-black text-white">
-  <div class="fluid-container-wider flex flex-col-reverse md:flex-row flex-wrap py-6 justify-between items-center uppercase">
+  <div class="fluid-container-wide flex flex-col-reverse md:flex-row flex-wrap py-6 justify-between items-center uppercase">
     <div class="flex flex-col">
       <div class="text-center sm:text-left">©{{ 'now'|date('Y') }} Your company</div>
       <div class="text-center sm:text-left">All Rights Reserved</div>


### PR DESCRIPTION
Added output of full, wide and narrow containers and elements on styleguide.

Added fluid-container-full and separated containers into
container.pcss.

Moved footer to full-width container on styleguide.
Changed within the footer the 'wider' container to 'wide'.

Moved user images to narrow width container on styleguide.

![image](https://user-images.githubusercontent.com/24897663/104589724-33c0f700-5662-11eb-906b-fc749e23d53b.png)

TB: 0.75h 