### PR TITLE
Whitelist is now called Safelist, update config

### DIFF
--- a/web/themes/custom/server_theme/tailwind.config.js
+++ b/web/themes/custom/server_theme/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
       '../../../modules/custom/**/*.php',
     ],
     options: {
-      whitelist: [
+      safelist: [
         // Add here custom class names.
       ],
     },


### PR DESCRIPTION
According to Tailwind docs, `whitelist` is now called `safelist`. Hopefully this saves someone time scratching their head wondering why it's not working :)

![image](https://user-images.githubusercontent.com/24897663/105028452-f33df080-5a48-11eb-8487-6ab460917ff3.png)
