### PR TITLE
Travis optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,34 +32,41 @@ jobs:
   include:
     - stage: Lint
       name: "PhpStan"
+      if: branch != "master" AND tag IS blank
       script:
         - "composer install"
         - "vendor/bin/phpstan analyse -c phpstan.neon"
     - stage: Lint
       name: "Drupal coding standard: phpcs"
+      if: branch != "master" AND tag IS blank
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_coder.sh || travis_terminate 1;"
         - "export REVIEW_STANDARD=\"Drupal\" && $TRAVIS_BUILD_DIR/ci-scripts/test_coder.sh"
     - stage: Lint
+      if: branch != "master" AND tag IS blank
       name: "Drupal coding best practices: phpcs"
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_coder.sh || travis_terminate 1;"
         - "export REVIEW_STANDARD=\"DrupalPractice\" && $TRAVIS_BUILD_DIR/ci-scripts/test_coder.sh"
     - stage: Lint
+      if: branch != "master" AND tag IS blank
       name: "Shell coding standard: shellcheck"
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_shell.sh || travis_terminate 1;"
         - "$TRAVIS_BUILD_DIR/ci-scripts/test_shell.sh || travis_terminate 1;"
     - stage: Test
       name: "Backend tests: Functional tests"
+      if: branch != "master" AND tag IS blank
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh || travis_terminate 1;"
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
         - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
     - stage: Deploy
-      name: "Deploy to Pantheon"
-      if: branch = "{{ GITHUB_DEPLOY_BRANCH }}" AND type = push
+      name: "Backend tests: Functional tests and deploy to Pantheon"
+      if: branch = "master" AND type = push
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh"
+        - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
+        - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
         - "$TRAVIS_BUILD_DIR/ci-scripts/prepare_deploy.sh"
         - "ddev robo deploy:pantheon --no-interaction {{ PANTHEON_DEPLOY_BRANCH }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,24 +32,20 @@ jobs:
   include:
     - stage: Lint
       name: "PhpStan"
-      if: branch != "master" AND tag IS blank
       script:
         - "composer install"
         - "vendor/bin/phpstan analyse -c phpstan.neon"
     - stage: Lint
       name: "Drupal coding standard: phpcs"
-      if: branch != "master" AND tag IS blank
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_coder.sh || travis_terminate 1;"
         - "export REVIEW_STANDARD=\"Drupal\" && $TRAVIS_BUILD_DIR/ci-scripts/test_coder.sh"
     - stage: Lint
-      if: branch != "master" AND tag IS blank
       name: "Drupal coding best practices: phpcs"
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_coder.sh || travis_terminate 1;"
         - "export REVIEW_STANDARD=\"DrupalPractice\" && $TRAVIS_BUILD_DIR/ci-scripts/test_coder.sh"
     - stage: Lint
-      if: branch != "master" AND tag IS blank
       name: "Shell coding standard: shellcheck"
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/install_shell.sh || travis_terminate 1;"

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -589,7 +589,7 @@ class RoboFile extends Tasks {
       ->to($pantheon_git_host)
       ->run();
     $this->taskReplaceInFile('.travis.yml')
-      ->from('{{ PANTHEON_DEPLOY_BRANCH }}')
+      ->from('master')
       ->to($pantheon_deploy_branch)
       ->run();
     $this->taskReplaceInFile('.travis.yml')


### PR DESCRIPTION
This way we only spin up DDEV once when the code is merged to master and we want to test and deploy.
Also it seems after we merged something, it's useless to lint.

It"s already used on client projects with satisfaction.