### PR TITLE
Do not do ssh-keyscan for auto-deploy

### DIFF
--- a/ci-scripts/prepare_deploy.sh
+++ b/ci-scripts/prepare_deploy.sh
@@ -11,9 +11,9 @@ chmod 600 ~/.ssh/id_rsa
 # Authenticate with Terminus.
 ddev . terminus auth:login --machine-token="$TERMINUS_TOKEN"
 
-ssh-keyscan -p 2222 "$GIT_HOST" >> ~/.ssh/known_hosts
+export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
 git clone "$PANTHEON_GIT_URL" .pantheon
 
-# Make the DDEV container aware of your ssh.
+# Make the DDEV container aware of your SSH keys.
 ddev auth ssh


### PR DESCRIPTION
On a client project, we faced with this:

```
The authenticity of host '[codeserver.dev.17e5f0a7-6478-4265-98c1-c36a7cdf7083.drush.in]:2222 ([35.224.10.91]:2222)' can't be established.

RSA key fingerprint is SHA256:yPEkh1Amd9WFBSP5syXD5rhUByTjaKBxQnlb5CahZZE.

Are you sure you want to continue connecting (yes/no)? 
```

So it seems to be smarter just to allow whatever we get.
`ssh-keyscan` anyways do not protect us from MITM attacks.