### PR TITLE
Release notes generator robustness

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1106,6 +1106,7 @@ END;
     curl_setopt($ch, CURLOPT_USERPWD, $username . ":" . $token);
     curl_setopt($ch, CURLOPT_TIMEOUT, 30);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
     $result = curl_exec($ch);
     curl_close($ch);
     return empty($result) ? NULL : json_decode($result);


### PR DESCRIPTION
https://docs.github.com/en/rest/overview/resources-in-the-rest-api#http-redirects

> Clients should assume that any request may result in a redirection. Receiving an HTTP redirection is not an error and clients should follow that redirect.