### PR TITLE
Do not set hard-wired admin pw by default

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -522,14 +522,6 @@ class RoboFile extends Tasks {
       ->exec("terminus remote:drush $pantheon_terminus_environment -- pm:uninstall migrate")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- uli");
 
-    // For these environments, set the `admin` user's password to `1234`.
-    $envs_to_set_admin_simple_password = [
-      'qa'
-    ];
-    if (in_array($env, $envs_to_set_admin_simple_password)) {
-      $task->exec("terminus remote:drush $pantheon_terminus_environment -- user:password admin 1234");
-    }
-
     $result = $task->run()->getExitCode();
 
     if ($result !== 0) {


### PR DESCRIPTION
As at the beginning, we might push QA database to `live`, this seems to be a bad idea - to do it by default for every site.