### PR TITLE
Update caniuse db with robo

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -353,19 +353,21 @@ class RoboFile extends Tasks {
     $this->taskExec("composer install --no-dev")->run();
 
     $rsync_exclude = [
-      '.git',
+      '.bootstrap-fast.php',
       '.ddev',
+      '.git',
       '.idea',
       '.pantheon',
-      'sites/default',
+      '.phpunit.result.cache',
+      'ci-scripts',
+      'drush',
       'pantheon.yml',
       'pantheon.upstream.yml',
+      'phpstan.neon',
+      'server.es.secrets.json',
+      'sites/default',
       'travis-key.enc',
       'travis-key',
-      'server.es.secrets.json',
-      '.bootstrap-fast.php',
-      'ci-scripts',
-      'phpstan.neon',
     ];
 
     $rsync_exclude_string = '--exclude=' . implode(' --exclude=', $rsync_exclude);

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1147,4 +1147,16 @@ END;
     return empty($result) ? NULL : json_decode($result);
   }
 
+  /**
+   * Update the caniuse-lite browserslist db.
+   *
+   * Any changes made as a result of this command should be committed.
+   *
+   * @return \Robo\ResultData
+   *   The result.
+   */
+  public function caniuseUpdatedb(): ResultData {
+    return $this->_exec('cd ' . self::THEME_BASE . ' && npx browserslist@latest --update-db');
+  }
+
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -150,7 +150,7 @@ class RoboFile extends Tasks {
         continue;
       }
 
-      $result = $this->_exec("cd " . self::THEME_BASE . " && ./node_modules/svgo/bin/svgo $directory/*.svg");
+      $result = $this->_exec("cd " . self::THEME_BASE . " && npx svgo $directory/*.svg");
       if (empty($error_code) && !$result->wasSuccessful()) {
         $error_code = $result->getExitCode();
       }

--- a/web/themes/custom/server_theme/package-lock.json
+++ b/web/themes/custom/server_theme/package-lock.json
@@ -247,12 +247,6 @@
         "node-releases": "^1.1.71"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001228",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-          "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
-          "dev": true
-        },
         "colorette": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -308,9 +302,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001159",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-      "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==",
+      "version": "1.0.30001279",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
       "dev": true
     },
     "chalk": {


### PR DESCRIPTION
* Update svgo command to use `npx` instead of hardcoded path

    ```bash
     [Filesystem\CopyDir] Copied from web/themes/custom/server_theme/src/images to web/themes/custom/server_theme/dist/images
     [Assets\ImageMinify] Found 0  files in web/themes/custom/server_theme/src/images/*.jpg
     [Assets\ImageMinify] Found 0  files in web/themes/custom/server_theme/src/images/*.png
     [Assets\ImageMinify] Minified 0 out of 0 images into web/themes/custom/server_theme/dist/images
     [Exec] Running cd web/themes/custom/server_theme &&
     npx svgo ./dist/images/*.svg
    
    chevron-right.svg:
    Done in 16 ms!
    0.229 KiB - 12.8% = 0.199 KiB
     [Exec] Done in 0.538s
    ```

* Added robo command to update/maintain the browserslists caniuse-lite db: `ddev robo caniuse:updatedb`
* Updated the list and committed the changes in package-lock.json in the theme dir.
    
    ```bash
    baysaa@fabbltd-baysaa:~/www/drupal-starter$ ddev robo caniuse:updatedb
     [Exec] Running cd web/themes/custom/server_theme &&
     npx browserslist@latest --update-db
    npx: installed 6 in 3.011s
    Browserslist: caniuse-lite is outdated. Please run:
    npx browserslist@latest --update-db
    
    Why you should do it regularly:
    https://github.com/browserslist/browserslist#browsers-data-updating
    Latest version:     1.0.30001279
    Installed versions: 1.0.30001159, 1.0.30001228
    Removing old caniuse-lite from lock file
    Installing new caniuse-lite version
    $ npm install caniuse-lite
    npm WARN server_theme No description
    npm WARN server_theme No repository field.
    npm WARN server_theme No license field.
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.2 (node_modules/fsevents):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.2 (node_modules/tailwindcss/node_modules/fsevents):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
    
    Cleaning package.json dependencies from caniuse-lite
    $ npm uninstall caniuse-lite
    npm WARN server_theme No description
    npm WARN server_theme No repository field.
    npm WARN server_theme No license field.
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.2 (node_modules/fsevents):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.2 (node_modules/tailwindcss/node_modules/fsevents):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
    
    caniuse-lite has been successfully updated
    
    Target browser changes:
    - and_chr 90
    + and_chr 95
    - and_ff 87
    + and_ff 92
    - android 90
    + android 95
    - chrome 90
    - chrome 89
    - chrome 88
    + chrome 95
    + chrome 94
    + chrome 93
    + chrome 92
    - edge 90
    - edge 89
    + edge 95
    + edge 94
    - firefox 88
    - firefox 87
    + firefox 94
    + firefox 93
    + firefox 92
    - ios_saf 14.5
    - ios_saf 13.4-13.7
    + ios_saf 15
    + ios_saf 14.5-14.8
    + ios_saf 12.2-12.5
    - op_mob 62
    + op_mob 64
    - opera 75
    - opera 74
    + opera 81
    + opera 80
    + opera 79
    - safari 14
    + safari 15
    + safari 13.1
    - samsung 13.0
    + samsung 15.0
     [Exec] Done in 10.238s
    ```

* Added to rsync_exclude list/array in Robofile:
  * `.phpunit.result.cache` which is just a test artefact 
  * `drush` since I noticed last deploy on a different project, the deploy had overwritten the pantheon drush.yml and was giving me jep-portal.ddev URLs for commands like `terminus drush uli`
* Re-ordered the rsync_exclude array alphabetically (files starting with dot are first)