### PR TITLE
Install coder 8.3.14 following latest config instructions

### DIFF
--- a/ci-scripts/install_coder.sh
+++ b/ci-scripts/install_coder.sh
@@ -8,6 +8,4 @@ set -e
 # ---------------------------------------------------------------------------- #
 
 cd "$TRAVIS_BUILD_DIR"
-COMPOSER_MEMORY_LIMIT=-1 composer global require slevomat/coding-standard:^7.0
-COMPOSER_MEMORY_LIMIT=-1 composer global require drupal/coder:^8.3.10
-phpcs --config-set installed_paths "$(readlink -f ~/.config/composer/vendor/drupal/coder/coder_sniffer)","$(readlink -f ~/.config/composer/vendor/slevomat/coding-standard)"
+COMPOSER_MEMORY_LIMIT=-1 composer global require drupal/coder:^8.3.14


### PR DESCRIPTION
According to this: https://www.drupal.org/node/3260071 it is no longer necessary to specify `installed_paths` for coder to work.