### PR TITLE
Add some basic styles to theme user related pages

### DIFF
--- a/web/themes/custom/server_theme/src/pcss/drupal.pcss
+++ b/web/themes/custom/server_theme/src/pcss/drupal.pcss
@@ -1,0 +1,10 @@
+body.path-user {
+  #block-server-theme-content {
+    @apply container-wide;
+  }
+
+  #edit-submit {
+    @apply bg-gray-500 hover:bg-gray-700 text-white py-2 px-4 rounded;
+  }
+}
+

--- a/web/themes/custom/server_theme/src/pcss/style.pcss
+++ b/web/themes/custom/server_theme/src/pcss/style.pcss
@@ -2,9 +2,9 @@
 @import "tailwindcss/components";
 
 @import "container.pcss";
-@import "typography.pcss";
-@import "list.pcss";
 @import "drupal.pcss";
+@import "list.pcss";
+@import "typography.pcss";
 
 // Must be last import.
 @import "tailwindcss/utilities";

--- a/web/themes/custom/server_theme/src/pcss/style.pcss
+++ b/web/themes/custom/server_theme/src/pcss/style.pcss
@@ -4,6 +4,7 @@
 @import "container.pcss";
 @import "typography.pcss";
 @import "list.pcss";
+@import "drupal.pcss";
 
 // Must be last import.
 @import "tailwindcss/utilities";


### PR DESCRIPTION
# Problem

By using tailwind, there are not default styles for login passwords. This is usually forgotten in projects and creates a really bad UX for users that cannot find the login button.

![Screenshot_2022-03-25_11-55-56](https://user-images.githubusercontent.com/5313631/160146095-1d5eabc4-f654-4027-9db0-36790bbb8ab7.png)

# Proposed solution

Let's add a minimal basic styles to prevent this

![Screenshot_2022-03-25_11-57-16](https://user-images.githubusercontent.com/5313631/160146086-535727bd-ca5e-4b73-bcee-e50c7466ae58.png)
![Screenshot_2022-03-25_11-57-03](https://user-images.githubusercontent.com/5313631/160146092-da3a97f1-fbae-4420-b901-a3a08c45e393.png)

