### PR TITLE
Add `ddev login` command

### DIFF
--- a/.ddev/commands/host/login
+++ b/.ddev/commands/host/login
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+## Description: Launch a browser and login to the current Drupal project.
+## Usage: login [--name=USER]
+## Example: "ddev login" or "ddev login --name=username" or "ddev login --uid=1"
+
+FULLURL=${DDEV_PRIMARY_URL}
+HTTPS=""
+if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi
+FULLURL=`ddev drush uli ${1}`
+
+case $OSTYPE in
+  linux-gnu)
+    xdg-open ${FULLURL}
+    ;;
+  "darwin"*)
+    open ${FULLURL}
+    ;;
+  "win*"* | "msys"*)
+    start ${FULLURL}
+    ;;
+esac

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ checking the outgoing mails.
     cp .ddev/config.local.yaml.example .ddev/config.local.yaml
     ddev restart
 
+**NOTE:** Once the Drupal installation is complete you can use `ddev login` to
+log in to the site as user 1 using your default browser.
+
 ### Troubleshooting
 
 If you had a previous installation of this repo, and have an error similar to `composer [install] failed, composer command failed: failed to load any docker-compose.*y*l files in /XXX/multi-repo/.ddev: err=<nil>. stderr=`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ checking the outgoing mails.
     cp .ddev/config.local.yaml.example .ddev/config.local.yaml
     ddev restart
 
-**NOTE:** Once the Drupal installation is complete you can use `ddev login` to
+Once the Drupal installation is complete you can use `ddev login` to
 log in to the site as user 1 using your default browser.
 
 ### Troubleshooting


### PR DESCRIPTION
Provides `ddev login` command, which opens the default browser and logs you in Drupal.

<a href="https://gitpod.io/#https://github.com/Gizra/drupal-starter/pull/258"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

