### PR TITLE
Ensure `deployPantheon` failures are reported as errors

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -257,6 +257,10 @@ class RoboFile extends Tasks {
     catch (Exception $e) {
       $this->yell('The deployment failed', 22, 'red');
       $this->say($e->getMessage());
+      // Ensure we exit with error as we're catching this exception.
+      $this->taskExec("git checkout $original_branch && exit 1")->run();
+      // Don't run the "finally {}" block as it will exit with code 0.
+      exit();
     }
     finally {
       $this->taskExec("git checkout $original_branch")->run();


### PR DESCRIPTION
If `git push` fails on the pantheon repo, the `finally {}` part of the code runs `git checkout $original_branch` which exits with code `0`, so the deploy continues running, and runs `deployPantheonSync`.

Since `finally` runs everytime, the only way I could think of was to utilize `exit()` in the `catch` to stop it from running if we get a failure. Although that kinda beats the purpose of `finally` but I haven't got the headspace right now to figure out a better solution :smile: Suggestions welcome.
