### PR TITLE
Pantheon uses the old-fashioned branch naming

### DIFF
--- a/ci-scripts/prepare_deploy.sh
+++ b/ci-scripts/prepare_deploy.sh
@@ -16,7 +16,7 @@ EOF
 
 export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
-git clone "$PANTHEON_GIT_URL" .pantheon
+git clone "$PANTHEON_GIT_URL" -b master .pantheon
 
 # Make the DDEV container aware of your SSH keys.
 ddev auth ssh


### PR DESCRIPTION
So if we clone the repository, we should force the name of the branch, otherwise repo-related checks like the existence of `pantheon.yml` would fail.

<a href="https://gitpod.io/#https://github.com/Gizra/drupal-starter/pull/278"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

