### PR TITLE
Add role for UID1 user

### DIFF
--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -31,5 +31,9 @@ hooks:
     # Enable Devel and Webprofiler
     - exec: drush pm-enable webprofiler -y
 
+    # Add administrator role to admin. Some role-only checks would choke
+    # for super admin otherwise.
+    - exec: drush user-add-role "administrator" admin
+
     # Generate one-time login link
     - exec: drush uli


### PR DESCRIPTION
Otherwise all role-based permission check needs to handle the edge case of UID1 that does not have any role but it's supposed to be able to do anything.

Credits to @andreytroeglazov , we concluded that this would be helpful on a client project.

<a href="https://gitpod.io/#https://github.com/Gizra/drupal-starter/pull/288"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

