### PR TITLE
ElasticSearch provision bugfix

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -768,7 +768,6 @@ class RoboFile extends Tasks {
    *   The password of the ES admin user.
    * @param string|null $environment
    *   The environment ID. To test changes in the index config selectively.
-   *   Default: NULL.
    *
    * @throws \Exception
    */


### PR DESCRIPTION
An annoying bug that happens when trying to provision new ES indices:

![image](https://user-images.githubusercontent.com/114076/187883346-b00f7dab-b91a-4eb0-93e3-54215a63cfa6.png)

for a multidev for instance

Robo tries to be smart by understanding the comments.

<a href="https://gitpod.io/#https://github.com/Gizra/drupal-starter/pull/293"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

