### PR TITLE
Set Homepage config after migration run

### DIFF
--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -21,6 +21,9 @@ hooks:
     - exec: drush migrate:import --group server
     - exec: drush pm-uninstall migrate -y
 
+    # Set the homepage
+    - exec: drush set-homepage
+
     # Clear cache, for example for entity view builder plugins to take effect.
     - exec: drush cr
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/advagg": "^4.1",
+        "drupal/config_ignore": "^2.3",
         "drupal/core-composer-scaffold": "^9.0.0",
         "drupal/core-project-message": "^9.0.0",
         "drupal/core-recommended": "^9.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f513e5f4117e36cacf635e1cd334a1b5",
+    "content-hash": "042829e222876d156e97961ac253ee70",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1954,6 +1954,133 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/advagg",
                 "issues": "https://drupal.org/project/issues/advagg",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/config_filter",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_filter.git",
+                "reference": "8.x-2.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_filter-8.x-2.4.zip",
+                "reference": "8.x-2.4",
+                "shasum": "dcf442f228dafd6bbac8948db1d51e3f1ca1d0c7"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9 || ^10"
+            },
+            "conflict": {
+                "drush/drush": "<10"
+            },
+            "suggest": {
+                "drupal/config_split": "Split site configuration for different environments."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.4",
+                    "datestamp": "1656936801",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "email": "opensource@fabianbircher.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Nuvole Web",
+                    "homepage": "http://nuvole.org",
+                    "email": "info@nuvole.org",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "pescetti",
+                    "homepage": "https://www.drupal.org/user/436244"
+                }
+            ],
+            "description": "Config Filter allows other modules to interact with a ConfigStorage through filter plugins.",
+            "homepage": "https://www.drupal.org/project/config_filter",
+            "keywords": [
+                "Drupal",
+                "configuration",
+                "configuration management"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/config_filter",
+                "issues": "https://www.drupal.org/project/issues/config_filter",
+                "slack": "https://drupal.slack.com/archives/C45342CDD"
+            }
+        },
+        {
+            "name": "drupal/config_ignore",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_ignore.git",
+                "reference": "8.x-2.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_ignore-8.x-2.3.zip",
+                "reference": "8.x-2.3",
+                "shasum": "2e1f07a455275fb6637909921a8915646601fc00"
+            },
+            "require": {
+                "drupal/config_filter": "^1 || ^2",
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.3",
+                    "datestamp": "1608306489",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Tommy Lynge Jørgensen",
+                    "homepage": "https://www.drupal.org/u/tlyngej",
+                    "email": "tlyngej@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "tlyngej",
+                    "homepage": "https://www.drupal.org/user/413139"
+                }
+            ],
+            "description": "Ignore certain configuration during import.",
+            "homepage": "http://drupal.org/project/config_ignore",
+            "support": {
+                "source": "https://git.drupalcode.org/project/config_ignore",
+                "issues": "http://drupal.org/project/config_ignore",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
+ignored_config_entities: {  }

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -1,3 +1,4 @@
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
-ignored_config_entities: {  }
+ignored_config_entities:
+  - 'system.site:page.front'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -12,6 +12,8 @@ module:
   color: 0
   comment: 0
   config: 0
+  config_filter: 0
+  config_ignore: 0
   contact: 0
   contextual: 0
   datetime: 0

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /homepage
+  front: /user/login
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en

--- a/web/modules/custom/server_general/composer.json
+++ b/web/modules/custom/server_general/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "server_general/server_general",
+    "type": "drupal-drush",
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^10"
+            }
+        }
+    }
+}

--- a/web/modules/custom/server_general/drush.services.yml
+++ b/web/modules/custom/server_general/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  server_general.commands:
+    class: Drupal\server_general\Commands\ServerGeneralCommands
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/server_general/drush.services.yml
+++ b/web/modules/custom/server_general/drush.services.yml
@@ -1,5 +1,6 @@
 services:
   server_general.commands:
     class: Drupal\server_general\Commands\ServerGeneralCommands
+    arguments: ['@entity_type.manager', '@config.factory']
     tags:
       - { name: drush.command }

--- a/web/modules/custom/server_general/src/Commands/ServerGeneralCommands.php
+++ b/web/modules/custom/server_general/src/Commands/ServerGeneralCommands.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\server_general\Commands;
 
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\node\NodeInterface;
 use Drush\Commands\DrushCommands;
 
@@ -10,6 +13,34 @@ use Drush\Commands\DrushCommands;
  * Server General Drush commands.
  */
 class ServerGeneralCommands extends DrushCommands {
+
+  /**
+   * Entity Type Manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Config Factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory) {
+    parent::__construct();
+    $this->entityTypeManager = $entity_type_manager;
+    $this->configFactory = $config_factory;
+  }
 
   /**
    * Command description here.
@@ -20,57 +51,28 @@ class ServerGeneralCommands extends DrushCommands {
    * @command server_general:set-homepage
    * @aliases set-homepage
    */
-  public function setHomepageAfterInstall() {
-    /** @var NodeInterface[] $homepage */
-    $homepage = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties([
+  public function setHomepageAfterInstall(): void {
+    /** @var \Drupal\node\NodeInterface[] $homepage */
+    $homepage = $this->entityTypeManager->getStorage('node')->loadByProperties([
       'title' => 'Homepage',
       'type' => 'landing_page',
       'status' => NodeInterface::PUBLISHED,
     ]);
+    /** @var \Consolidation\Log\Logger $logger */
+    $logger = $this->logger();
     if (empty($homepage)) {
-      $this->logger()->error(dt('Unable to find any published landing_page nodes titled "Homepage".'));
+      $logger->error(dt('Unable to find any published landing_page nodes titled "Homepage".'));
       return;
     }
 
     $homepage = reset($homepage);
     $front = "/node/{$homepage->id()}";
-    $config = \Drupal::configFactory()->getEditable('system.site');
+    $config = $this->configFactory->getEditable('system.site');
     $config->set('page.front', $front);
     $config->save();
-
-    $this->logger()->success(dt('Homepage set to @front.', [
+    $logger->success(dt('Homepage set to @front.', [
       '@front' => $front,
     ]));
   }
 
-  /**
-   * An example of the table output format.
-   *
-   * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
-   *
-   * @field-labels
-   *   group: Group
-   *   token: Token
-   *   name: Name
-   * @default-fields group,token,name
-   *
-   * @command server_general:token
-   * @aliases token
-   *
-   * @filter-default-field name
-   * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
-   */
-  public function token($options = ['format' => 'table']) {
-    $all = \Drupal::token()->getInfo();
-    foreach ($all['tokens'] as $group => $tokens) {
-      foreach ($tokens as $key => $token) {
-        $rows[] = [
-          'group' => $group,
-          'token' => $key,
-          'name' => $token['name'],
-        ];
-      }
-    }
-    return new RowsOfFields($rows);
-  }
 }

--- a/web/modules/custom/server_general/src/Commands/ServerGeneralCommands.php
+++ b/web/modules/custom/server_general/src/Commands/ServerGeneralCommands.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\server_general\Commands;
+
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drupal\node\NodeInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Server General Drush commands.
+ */
+class ServerGeneralCommands extends DrushCommands {
+
+  /**
+   * Command description here.
+   *
+   * @usage server_general:set-homepage
+   *   Sets the homepage to the migrated "Homepage" landing page node.
+   *
+   * @command server_general:set-homepage
+   * @aliases set-homepage
+   */
+  public function setHomepageAfterInstall() {
+    /** @var NodeInterface[] $homepage */
+    $homepage = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties([
+      'title' => 'Homepage',
+      'type' => 'landing_page',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    if (empty($homepage)) {
+      $this->logger()->error(dt('Unable to find any published landing_page nodes titled "Homepage".'));
+      return;
+    }
+
+    $homepage = reset($homepage);
+    $front = "/node/{$homepage->id()}";
+    $config = \Drupal::configFactory()->getEditable('system.site');
+    $config->set('page.front', $front);
+    $config->save();
+
+    $this->logger()->success(dt('Homepage set to @front.', [
+      '@front' => $front,
+    ]));
+  }
+
+  /**
+   * An example of the table output format.
+   *
+   * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
+   *
+   * @field-labels
+   *   group: Group
+   *   token: Token
+   *   name: Name
+   * @default-fields group,token,name
+   *
+   * @command server_general:token
+   * @aliases token
+   *
+   * @filter-default-field name
+   * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+   */
+  public function token($options = ['format' => 'table']) {
+    $all = \Drupal::token()->getInfo();
+    foreach ($all['tokens'] as $group => $tokens) {
+      foreach ($tokens as $key => $token) {
+        $rows[] = [
+          'group' => $group,
+          'token' => $key,
+          'name' => $token['name'],
+        ];
+      }
+    }
+    return new RowsOfFields($rows);
+  }
+}


### PR DESCRIPTION
#259 

- Revert homepage back to default:
   ![image](https://user-images.githubusercontent.com/24897663/190430618-4443f2ab-c46c-4b0e-ba49-3c516dbfc483.png)
- Install `config_ignore` and configure it to **not revert** any changes to the homepage configuration
- Created drush command in `server_general` to set homepage to landing page with name "Homepage":  `drush set-homepage`
- Call the drush command from `config.local.yaml.example` after the migrations run. See below: "Homepage set to /node/7"

![image](https://user-images.githubusercontent.com/24897663/190431104-a4ec69dc-aff2-434a-a7b8-5612e510eab1.png)

Homepage output:

![image](https://user-images.githubusercontent.com/24897663/190431231-81efb8a3-5fb6-4eb7-8b98-a2fb6a4c8b22.png)

TB: 1.5h