### PR TITLE
Add assertFieldIsRequired tests to Content types and Paragraph types

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/RequiredAndOptionalFieldTestInterface.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/RequiredAndOptionalFieldTestInterface.php
@@ -26,7 +26,7 @@ interface RequiredAndOptionalFieldTestInterface {
   /**
    * The required fields for entity bundle.
    *
-   * @return array
+   * @return string[]
    *   Array of required field names.
    */
   public function getRequiredFields() : array;
@@ -34,7 +34,7 @@ interface RequiredAndOptionalFieldTestInterface {
   /**
    * The optional fields for entity bundle.
    *
-   * @return array
+   * @return string[]
    *   Array of optional field names.
    */
   public function getOptionalFields() : array;

--- a/web/modules/custom/server_general/tests/src/ExistingSite/RequiredAndOptionalFieldTestInterface.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/RequiredAndOptionalFieldTestInterface.php
@@ -2,10 +2,13 @@
 
 namespace Drupal\Tests\server_general\ExistingSite;
 
+/**
+ * Interface defining required function for required/optional field tests.
+ */
 interface RequiredAndOptionalFieldTestInterface {
 
   /**
-   *  The entity type to assert it exists.
+   * The entity type to assert it exists.
    *
    * @return string
    *   An entity type name.
@@ -13,7 +16,7 @@ interface RequiredAndOptionalFieldTestInterface {
   public function getEntityType() : string;
 
   /**
-   *  The entity bundle to assert it exists.
+   * The entity bundle to assert it exists.
    *
    * @return string
    *   A bundle name.
@@ -21,7 +24,7 @@ interface RequiredAndOptionalFieldTestInterface {
   public function getEntityBundle() : string;
 
   /**
-   *  The required fields for entity bundle.
+   * The required fields for entity bundle.
    *
    * @return array
    *   Array of required field names.
@@ -29,10 +32,11 @@ interface RequiredAndOptionalFieldTestInterface {
   public function getRequiredFields() : array;
 
   /**
-   *  The optional fields for entity bundle.
+   * The optional fields for entity bundle.
    *
    * @return array
    *   Array of optional field names.
    */
   public function getOptionalFields() : array;
+
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/RequiredAndOptionalFieldTestInterface.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/RequiredAndOptionalFieldTestInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+interface RequiredAndOptionalFieldTestInterface {
+
+  /**
+   *  The entity type to assert it exists.
+   *
+   * @return string
+   *   An entity type name.
+   */
+  public function getEntityType() : string;
+
+  /**
+   *  The entity bundle to assert it exists.
+   *
+   * @return string
+   *   A bundle name.
+   */
+  public function getEntityBundle() : string;
+
+  /**
+   *  The required fields for entity bundle.
+   *
+   * @return array
+   *   Array of required field names.
+   */
+  public function getRequiredFields() : array;
+
+  /**
+   *  The optional fields for entity bundle.
+   *
+   * @return array
+   *   Array of optional field names.
+   */
+  public function getOptionalFields() : array;
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeLandingPageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeLandingPageTest.php
@@ -10,11 +10,29 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ServerGeneralContentTypeLandingPageTest extends ServerGeneralContentTypeTestBase {
 
-  const ENTITY_BUNDLE = 'landing_page';
-  const OPTIONAL_FIELDS = [
-    'field_is_title_hidden',
-    'field_paragraphs',
-  ];
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'landing_page';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequiredFields(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptionalFields(): array {
+    return [
+      'field_is_title_hidden',
+      'field_paragraphs',
+    ];
+  }
 
   /**
    * Test the permissions and available paragraphs.

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeLandingPageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeLandingPageTest.php
@@ -4,12 +4,17 @@ namespace Drupal\Tests\server_general\ExistingSite;
 
 use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\HttpFoundation\Response;
-use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
- * Test Landing page functionality.
+ * Test 'landing_page' content type.
  */
-class ServerGeneralLandingPageTest extends ExistingSiteBase {
+class ServerGeneralContentTypeLandingPageTest extends ServerGeneralContentTypeTestBase {
+
+  const ENTITY_BUNDLE = 'landing_page';
+  const OPTIONAL_FIELDS = [
+    'field_is_title_hidden',
+    'field_paragraphs',
+  ];
 
   /**
    * Test the permissions and available paragraphs.

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeNews.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeNews.php
@@ -7,13 +7,30 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 class ServerGeneralContentTypeNews extends ServerGeneralContentTypeTestBase {
 
-  const ENTITY_BUNDLE = 'news';
-  const REQUIRED_FIELDS = [
-    'field_body',
-  ];
-  const OPTIONAL_FIELDS = [
-    'field_featured_image',
-    'field_tags',
-  ];
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'news';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequiredFields(): array {
+    return [
+      'field_body',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptionalFields(): array {
+    return [
+      'field_featured_image',
+      'field_tags',
+    ];
+  }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeNews.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeNews.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Test 'news' content type.
+ */
+class ServerGeneralContentTypeNews extends ServerGeneralContentTypeTestBase {
+
+  const ENTITY_BUNDLE = 'news';
+  const REQUIRED_FIELDS = [
+    'field_body',
+  ];
+  const OPTIONAL_FIELDS = [
+    'field_featured_image',
+    'field_tags',
+  ];
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeTestBase.php
@@ -7,6 +7,11 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 abstract class ServerGeneralContentTypeTestBase extends ServerGeneralEntityTypeTestBase {
 
-  const ENTITY_TYPE = 'node';
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityType(): string {
+    return 'node';
+  }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralContentTypeTestBase.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Abstract class to hold shared logic to check various content types.
+ */
+abstract class ServerGeneralContentTypeTestBase extends ServerGeneralEntityTypeTestBase {
+
+  const ENTITY_TYPE = 'node';
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralEntityTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralEntityTypeTestBase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Drupal\Tests\drupal_test_assertions\Assertions\EntityTrait;
+use Drupal\Tests\drupal_test_assertions\Assertions\FieldsTrait;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Abstract class to hold shared logic to check various content-types.
+ */
+abstract class ServerGeneralEntityTypeTestBase extends ExistingSiteBase {
+
+  use EntityTrait;
+  use FieldsTrait;
+
+  const ENTITY_TYPE = '';
+  const ENTITY_BUNDLE = '';
+  const REQUIRED_FIELDS = [];
+  const OPTIONAL_FIELDS = [];
+
+  /**
+   * Test Required and Not requierd fields for this entity bundle.
+   */
+  public function testFields() {
+    $entity_type = static::ENTITY_TYPE;
+    $entity_bundle = static::ENTITY_BUNDLE;
+
+    $this->assertEntityExists($entity_type, $entity_bundle);
+
+    foreach (static::REQUIRED_FIELDS as $field_name) {
+      $this->assertFieldIsRequired($field_name, $entity_type, $entity_bundle);
+    }
+
+    foreach (static::OPTIONAL_FIELDS as $field_name) {
+      $this->assertFieldIsNotRequired($field_name, $entity_type, $entity_bundle);
+    }
+  }
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralEntityTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralEntityTypeTestBase.php
@@ -9,30 +9,25 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 /**
  * Abstract class to hold shared logic to check various content-types.
  */
-abstract class ServerGeneralEntityTypeTestBase extends ExistingSiteBase {
+abstract class ServerGeneralEntityTypeTestBase extends ExistingSiteBase implements RequiredAndOptionalFieldTestInterface{
 
   use EntityTrait;
   use FieldsTrait;
-
-  const ENTITY_TYPE = '';
-  const ENTITY_BUNDLE = '';
-  const REQUIRED_FIELDS = [];
-  const OPTIONAL_FIELDS = [];
 
   /**
    * Test Required and Not requierd fields for this entity bundle.
    */
   public function testFields() {
-    $entity_type = static::ENTITY_TYPE;
-    $entity_bundle = static::ENTITY_BUNDLE;
+    $entity_type = $this->getEntityType();
+    $entity_bundle = $this->getEntityBundle();
 
     $this->assertEntityExists($entity_type, $entity_bundle);
 
-    foreach (static::REQUIRED_FIELDS as $field_name) {
+    foreach ($this->getRequiredFields() as $field_name) {
       $this->assertFieldIsRequired($field_name, $entity_type, $entity_bundle);
     }
 
-    foreach (static::OPTIONAL_FIELDS as $field_name) {
+    foreach ($this->getOptionalFields() as $field_name) {
       $this->assertFieldIsNotRequired($field_name, $entity_type, $entity_bundle);
     }
   }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralEntityTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralEntityTypeTestBase.php
@@ -9,7 +9,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 /**
  * Abstract class to hold shared logic to check various content-types.
  */
-abstract class ServerGeneralEntityTypeTestBase extends ExistingSiteBase implements RequiredAndOptionalFieldTestInterface{
+abstract class ServerGeneralEntityTypeTestBase extends ExistingSiteBase implements RequiredAndOptionalFieldTestInterface {
 
   use EntityTrait;
   use FieldsTrait;

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeCtaTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeCtaTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Test 'cta' paragraph type.
+ */
+class ServerGeneralParagraphTypeCtaTest extends ServerGeneralParagraphTypeTestBase {
+
+  const ENTITY_BUNDLE = 'cta';
+  const REQUIRED_FIELDS = [
+    'field_link',
+    'field_subtitle',
+    'field_title',
+  ];
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeCtaTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeCtaTest.php
@@ -7,11 +7,29 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 class ServerGeneralParagraphTypeCtaTest extends ServerGeneralParagraphTypeTestBase {
 
-  const ENTITY_BUNDLE = 'cta';
-  const REQUIRED_FIELDS = [
-    'field_link',
-    'field_subtitle',
-    'field_title',
-  ];
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'cta';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequiredFields(): array {
+    return [
+      'field_link',
+      'field_subtitle',
+      'field_title',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptionalFields(): array {
+    return [];
+  }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeHeroImageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeHeroImageTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Test 'hero_image' paragraph type.
+ */
+class ServerGeneralParagraphTypeHeroImageTest extends ServerGeneralParagraphTypeTestBase {
+
+  const ENTITY_BUNDLE = 'hero_image';
+  const REQUIRED_FIELDS = [
+    'field_title',
+    'field_image',
+  ];
+  const OPTIONAL_FIELDS = [
+    'field_link',
+    'field_subtitle',
+  ];
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeHeroImageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeHeroImageTest.php
@@ -7,14 +7,31 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 class ServerGeneralParagraphTypeHeroImageTest extends ServerGeneralParagraphTypeTestBase {
 
-  const ENTITY_BUNDLE = 'hero_image';
-  const REQUIRED_FIELDS = [
-    'field_title',
-    'field_image',
-  ];
-  const OPTIONAL_FIELDS = [
-    'field_link',
-    'field_subtitle',
-  ];
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'hero_image';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequiredFields(): array {
+    return [
+      'field_title',
+      'field_image',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptionalFields(): array {
+    return [
+      'field_link',
+      'field_subtitle',
+    ];
+  }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeRelatedContentTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeRelatedContentTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Test 'related_content' paragraph type.
+ */
+class ServerGeneralParagraphTypeRelatedContentTest extends ServerGeneralParagraphTypeTestBase {
+
+  const ENTITY_BUNDLE = 'related_content';
+  const REQUIRED_FIELDS = [
+    'field_title',
+    'field_related_content',
+  ];
+  const OPTIONAL_FIELDS = [
+    'field_link',
+  ];
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeRelatedContentTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeRelatedContentTest.php
@@ -7,13 +7,30 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 class ServerGeneralParagraphTypeRelatedContentTest extends ServerGeneralParagraphTypeTestBase {
 
-  const ENTITY_BUNDLE = 'related_content';
-  const REQUIRED_FIELDS = [
-    'field_title',
-    'field_related_content',
-  ];
-  const OPTIONAL_FIELDS = [
-    'field_link',
-  ];
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'related_content';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequiredFields(): array {
+    return [
+      'field_title',
+      'field_related_content',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptionalFields(): array {
+    return [
+      'field_link',
+    ];
+  }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTestBase.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Abstract class to hold shared logic to check various paragraph types.
+ */
+abstract class ServerGeneralParagraphTypeTestBase extends ServerGeneralEntityTypeTestBase {
+
+  const ENTITY_TYPE = 'paragraph';
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTestBase.php
@@ -7,6 +7,11 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 abstract class ServerGeneralParagraphTypeTestBase extends ServerGeneralEntityTypeTestBase {
 
-  const ENTITY_TYPE = 'paragraph';
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityType(): string {
+    return 'paragraph';
+  }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTextTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTextTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Test 'text' paragraph type.
+ */
+class ServerGeneralParagraphTypeTextTest extends ServerGeneralParagraphTypeTestBase {
+
+  const ENTITY_BUNDLE = 'text';
+  const REQUIRED_FIELDS = [
+    'field_body',
+  ];
+  const OPTIONAL_FIELDS = [
+    'field_title',
+  ];
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTextTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTextTest.php
@@ -7,12 +7,29 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 class ServerGeneralParagraphTypeTextTest extends ServerGeneralParagraphTypeTestBase {
 
-  const ENTITY_BUNDLE = 'text';
-  const REQUIRED_FIELDS = [
-    'field_body',
-  ];
-  const OPTIONAL_FIELDS = [
-    'field_title',
-  ];
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'text';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequiredFields(): array {
+    return [
+      'field_body',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptionalFields(): array {
+    return [
+      'field_title',
+    ];
+  }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeViewsTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeViewsTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Test 'views' paragraph type.
+ */
+class ServerGeneralParagraphTypeViewsTest extends ServerGeneralParagraphTypeTestBase {
+
+  const ENTITY_BUNDLE = 'views';
+  const OPTIONAL_FIELDS = [
+    'field_views',
+  ];
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeViewsTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeViewsTest.php
@@ -7,9 +7,27 @@ namespace Drupal\Tests\server_general\ExistingSite;
  */
 class ServerGeneralParagraphTypeViewsTest extends ServerGeneralParagraphTypeTestBase {
 
-  const ENTITY_BUNDLE = 'views';
-  const OPTIONAL_FIELDS = [
-    'field_views',
-  ];
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityBundle(): string {
+    return 'views';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRequiredFields(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptionalFields(): array {
+    return [
+      'field_views',
+    ];
+  }
 
 }


### PR DESCRIPTION
#289 

- Add `assertFieldIsRequired` & 'assertFieldIsNotRequired' tests to Content types and Paragraph types.

**TB:1.7/2h**