### PR TITLE
Do not cache phpunit result on CI

### DIFF
--- a/ci-scripts/test_phpunit.sh
+++ b/ci-scripts/test_phpunit.sh
@@ -4,6 +4,6 @@ set -e
 # -------------------------------------------------- #
 # Run PHPUnit tests
 # -------------------------------------------------- #
-ddev phpunit --testdox
+ddev phpunit --do-not-cache-result --testdox
 
 exit 0


### PR DESCRIPTION
It might get accidentally deployed, if a project isn't deployed to Pantheon or via the standard RoboFile. also it's not useful in CI environment in any ways.