### PR TITLE
Add Migrate source database

### DIFF
--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -1,3 +1,9 @@
+web_environment:
+  - COMPOSER_EXIT_ON_PATCH_FAILURE=1
+  # Un comment when working on a migration and the source is different DDEV
+  # installation. And Change the `SomeName` to match the remote source.
+  # This is used in setting.ddev.php
+  # - DDEV_MIGRATE_REMOTE_SOURCE=ddev-SomeName-db
 hooks:
   post-start:
     # Private files directory.

--- a/web/sites/default/settings.ddev.php
+++ b/web/sites/default/settings.ddev.php
@@ -25,6 +25,21 @@ $databases['default']['default'] = array(
   'prefix' => "",
 );
 
+// Migrate source database.
+$ddev_migrate_remote_source = getenv('DDEV_MIGRATE_REMOTE_SOURCE');
+if (!empty($ddev_migrate_remote_source) && gethostbyname($ddev_migrate_remote_source) !== $ddev_migrate_remote_source) {
+  $databases['migrate']['default'] = [
+    'database' => 'db',
+    'username' => 'db',
+    'password' => 'db',
+    'prefix' => '',
+    'host' => $ddev_migrate_remote_source,
+    'port' => '3306',
+    'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+    'driver' => 'mysql',
+  ];
+}
+
 // Fake migrate default source to eliminate a warning about missing
 // database connection.
 // @todo: replace it with real, external credentials if needed.


### PR DESCRIPTION
When migrating from another DDEV it would be possible to describe the location of the source DDEV installation.

`gethostbyname` which is an expensive call, would be called only when the PHP env `DDEV_MIGRATE_REMOTE_SOURCE` would be set