### PR TITLE
Add assertFieldIsRequired tests to Content types and Paragraph types - Follow-ups

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralFieldableEntityTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralFieldableEntityTestBase.php
@@ -9,7 +9,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 /**
  * Abstract class to hold shared logic to check various content-types.
  */
-abstract class ServerGeneralEntityTypeTestBase extends ExistingSiteBase implements RequiredAndOptionalFieldTestInterface {
+abstract class ServerGeneralFieldableEntityTestBase extends ExistingSiteBase implements RequiredAndOptionalFieldTestInterface {
 
   use EntityTrait;
   use FieldsTrait;

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeLandingPageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeLandingPageTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Test 'landing_page' content type.
  */
-class ServerGeneralContentTypeLandingPageTest extends ServerGeneralContentTypeTestBase {
+class ServerGeneralNodeLandingPageTest extends ServerGeneralNodeTestBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeNewsTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeNewsTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\server_general\ExistingSite;
 /**
  * Test 'news' content type.
  */
-class ServerGeneralContentTypeNewsTest extends ServerGeneralContentTypeTestBase {
+class ServerGeneralNodeNewsTest extends ServerGeneralNodeTestBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeTestBase.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\server_general\ExistingSite;
 /**
  * Abstract class to hold shared logic to check various content types.
  */
-abstract class ServerGeneralContentTypeTestBase extends ServerGeneralEntityTypeTestBase {
+abstract class ServerGeneralNodeTestBase extends ServerGeneralFieldableEntityTestBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphCtaTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphCtaTest.php
@@ -3,15 +3,15 @@
 namespace Drupal\Tests\server_general\ExistingSite;
 
 /**
- * Test 'hero_image' paragraph type.
+ * Test 'cta' paragraph type.
  */
-class ServerGeneralParagraphTypeHeroImageTest extends ServerGeneralParagraphTypeTestBase {
+class ServerGeneralParagraphCtaTest extends ServerGeneralParagraphTestBase {
 
   /**
    * {@inheritdoc}
    */
   public function getEntityBundle(): string {
-    return 'hero_image';
+    return 'cta';
   }
 
   /**
@@ -19,8 +19,9 @@ class ServerGeneralParagraphTypeHeroImageTest extends ServerGeneralParagraphType
    */
   public function getRequiredFields(): array {
     return [
+      'field_link',
+      'field_subtitle',
       'field_title',
-      'field_image',
     ];
   }
 
@@ -28,10 +29,7 @@ class ServerGeneralParagraphTypeHeroImageTest extends ServerGeneralParagraphType
    * {@inheritdoc}
    */
   public function getOptionalFields(): array {
-    return [
-      'field_link',
-      'field_subtitle',
-    ];
+    return [];
   }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphHeroImageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphHeroImageTest.php
@@ -3,15 +3,15 @@
 namespace Drupal\Tests\server_general\ExistingSite;
 
 /**
- * Test 'views' paragraph type.
+ * Test 'hero_image' paragraph type.
  */
-class ServerGeneralParagraphTypeViewsTest extends ServerGeneralParagraphTypeTestBase {
+class ServerGeneralParagraphHeroImageTest extends ServerGeneralParagraphTestBase {
 
   /**
    * {@inheritdoc}
    */
   public function getEntityBundle(): string {
-    return 'views';
+    return 'hero_image';
   }
 
   /**
@@ -19,7 +19,8 @@ class ServerGeneralParagraphTypeViewsTest extends ServerGeneralParagraphTypeTest
    */
   public function getRequiredFields(): array {
     return [
-      'field_views',
+      'field_title',
+      'field_image',
     ];
   }
 
@@ -27,7 +28,10 @@ class ServerGeneralParagraphTypeViewsTest extends ServerGeneralParagraphTypeTest
    * {@inheritdoc}
    */
   public function getOptionalFields(): array {
-    return [];
+    return [
+      'field_link',
+      'field_subtitle',
+    ];
   }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphRelatedContentTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphRelatedContentTest.php
@@ -3,15 +3,15 @@
 namespace Drupal\Tests\server_general\ExistingSite;
 
 /**
- * Test 'cta' paragraph type.
+ * Test 'related_content' paragraph type.
  */
-class ServerGeneralParagraphTypeCtaTest extends ServerGeneralParagraphTypeTestBase {
+class ServerGeneralParagraphRelatedContentTest extends ServerGeneralParagraphTestBase {
 
   /**
    * {@inheritdoc}
    */
   public function getEntityBundle(): string {
-    return 'cta';
+    return 'related_content';
   }
 
   /**
@@ -19,9 +19,8 @@ class ServerGeneralParagraphTypeCtaTest extends ServerGeneralParagraphTypeTestBa
    */
   public function getRequiredFields(): array {
     return [
-      'field_link',
-      'field_subtitle',
       'field_title',
+      'field_related_content',
     ];
   }
 
@@ -29,7 +28,9 @@ class ServerGeneralParagraphTypeCtaTest extends ServerGeneralParagraphTypeTestBa
    * {@inheritdoc}
    */
   public function getOptionalFields(): array {
-    return [];
+    return [
+      'field_link',
+    ];
   }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTestBase.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\server_general\ExistingSite;
 /**
  * Abstract class to hold shared logic to check various paragraph types.
  */
-abstract class ServerGeneralParagraphTypeTestBase extends ServerGeneralFieldableEntityTestBase {
+abstract class ServerGeneralParagraphTestBase extends ServerGeneralFieldableEntityTestBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTextTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTextTest.php
@@ -3,15 +3,15 @@
 namespace Drupal\Tests\server_general\ExistingSite;
 
 /**
- * Test 'related_content' paragraph type.
+ * Test 'text' paragraph type.
  */
-class ServerGeneralParagraphTypeRelatedContentTest extends ServerGeneralParagraphTypeTestBase {
+class ServerGeneralParagraphTextTest extends ServerGeneralParagraphTestBase {
 
   /**
    * {@inheritdoc}
    */
   public function getEntityBundle(): string {
-    return 'related_content';
+    return 'text';
   }
 
   /**
@@ -19,8 +19,7 @@ class ServerGeneralParagraphTypeRelatedContentTest extends ServerGeneralParagrap
    */
   public function getRequiredFields(): array {
     return [
-      'field_title',
-      'field_related_content',
+      'field_body',
     ];
   }
 
@@ -29,7 +28,7 @@ class ServerGeneralParagraphTypeRelatedContentTest extends ServerGeneralParagrap
    */
   public function getOptionalFields(): array {
     return [
-      'field_link',
+      'field_title',
     ];
   }
 

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphTypeTestBase.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\server_general\ExistingSite;
 /**
  * Abstract class to hold shared logic to check various paragraph types.
  */
-abstract class ServerGeneralParagraphTypeTestBase extends ServerGeneralEntityTypeTestBase {
+abstract class ServerGeneralParagraphTypeTestBase extends ServerGeneralFieldableEntityTestBase {
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphViewsTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphViewsTest.php
@@ -3,15 +3,15 @@
 namespace Drupal\Tests\server_general\ExistingSite;
 
 /**
- * Test 'text' paragraph type.
+ * Test 'views' paragraph type.
  */
-class ServerGeneralParagraphTypeTextTest extends ServerGeneralParagraphTypeTestBase {
+class ServerGeneralParagraphViewsTest extends ServerGeneralParagraphTestBase {
 
   /**
    * {@inheritdoc}
    */
   public function getEntityBundle(): string {
-    return 'text';
+    return 'views';
   }
 
   /**
@@ -19,7 +19,7 @@ class ServerGeneralParagraphTypeTextTest extends ServerGeneralParagraphTypeTestB
    */
   public function getRequiredFields(): array {
     return [
-      'field_body',
+      'field_views',
     ];
   }
 
@@ -27,9 +27,7 @@ class ServerGeneralParagraphTypeTextTest extends ServerGeneralParagraphTypeTestB
    * {@inheritdoc}
    */
   public function getOptionalFields(): array {
-    return [
-      'field_title',
-    ];
+    return [];
   }
 
 }


### PR DESCRIPTION
#289 

### Update:
Updated class names:
- `ServerGeneralEntityTypeTestBase` => `ServerGeneralFieldableEntityTestBase`
- `ServerGeneralContentTypeTestBase` => `ServerGeneralNodeTestBase`
- `ServerGeneralContentTypeLandingPageTest`  => `ServerGeneralNodeLandingPageTest` 
- `ServerGeneralContentTypeNewsTest` => `ServerGeneralNodeNewsTest`
- `ServerGeneralParagraphTypeTestBase` => `ServerGeneralParagraphTestBase`
- `ServerGeneralParagraphTypeCtaTest` => `ServerGeneralParagraphCtaTest`
- `ServerGeneralParagraphTypeHeroImageTest` => `ServerGeneralParagraphHeroImageTest`
- `ServerGeneralParagraphTypeRelatedContentTest` => `ServerGeneralParagraphRelatedContentTest `
- `ServerGeneralParagraphTypeTextTest` => `ServerGeneralParagraphTextTest`
- `ServerGeneralParagraphTypeViewsTest` => `ServerGeneralParagraphViewsTest`

**TB: 0.4h**
