### PR TITLE
Revert "Update theme watch to include js & images."

### DIFF
--- a/.ddev/commands/web/theme:watch
+++ b/.ddev/commands/web/theme:watch
@@ -4,4 +4,4 @@
 ## Usage: theme:watch
 ## Example: "ddev theme:watch"
 
-./vendor/bin/robo theme:watch
+cd ./web/themes/custom/server_theme && npx postcss ./src/pcss/style.pcss --output=./dist/css/style.css --watch --verbose

--- a/.ddev/commands/web/theme:watch-css
+++ b/.ddev/commands/web/theme:watch-css
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-## Description: Run theme compile, watch for changes.
-## Usage: theme:watch-css
-## Example: "ddev theme:watch-css"
-
-cd ./web/themes/custom/server_theme && npm install && npx postcss ./src/pcss/style.pcss --output=./dist/css/style.css --watch --verbose

--- a/README.md
+++ b/README.md
@@ -45,55 +45,26 @@ then execute the following, and re-try installation steps.
 
 ## Theme Development
 
-For theme development, it's advisable to entirely turn off caching: https://www.drupal.org/node/2598914
+By default, `ddev restart` compiles the theme using Robo (`ddev robo theme:compile-debug`)
 
-### The directory structure
- - `src/` - put all source stylesheets images, fonts, etc here.
- - `dist/` - `.gitignore`-ed path where the compiled / optimized files live, the theme should refer the assets from that directory.
+This is used only for watching Tailwind styles, it's not compiling js, images, etc.
 
-### Compiling assests
-All assets are compiled at DDEV startup using `ddev robo theme:compile-debug`.
+On the local development environment, which is using TailWind's [JIT](https://tailwindcss.com/docs/just-in-time-mode) (Just-In-Time), execute:
 
-To compile assets during development run:
 ```bash
 ddev theme:watch
 ```
-This will compile Tailwind styles, JS & Images and keep watching for any changes. This also rebuilds Drupal cache on any change and thus could be a little slower.
 
-If you just want to compile & watch tailwind, run `ddev theme:watch-css`. This will be much faster.
+This will compile Tailwind and keep watching for any changes.
 
+When running `ddev robo theme:compile` it will purge any TailWind's CSS class
+which is not found in the code, twig, or under `tailwind.config.js` `whitelist` property.
 
-### Compilation & Watch process
-#### CSS
-We use postcss (with tailwind plugin) to compile CSS assets.
-See `postcss.config.js` for the compile pipeline. To oversimplify:
-1. Tailwind plugin is used to compile the files.
-2. Followed by nanocss plugin to minify.
+The directory structure:
+ - `src/` - put all source stylesheets images, fonts, etc here.
+ - `dist/` - `.gitignore`-ed path where the compiled / optimized files live, the theme should refer the assets from that directory.
 
-#### JS & Images
-We have two compilation modes for JS & Images:
-1. Simple compilation
-2. Optimized compilation
-
-##### Simple compilation
-In simple compilation, the js & images files are simply copied from `/src` to
-their corresponding `/dist` directories.
-
-For simple compilation, run `ddev robo theme:compile`
-
-##### Optimized compilation
-In optimized compilation:
-- The js files from `/src/js` are first minified using Robo's `taskMinify` task
-and then copied over to `dist/js`. This is done using `Patchwork/JSqueeze`
-package.
-- The image files are also optimized using Robo's `taskImageMinify` task and
-then copied over to `dist/images`. See `/Robo/Tasks/Assets/ImageMinify` to see
-the list of optimizers used.
-
-For optimized compilation, run `ddev robo theme:compile-debug`
-
-Please note that in both cases, the css is also compiled using
-postcss (with tailwind plugin).
+For theme development, it's advisable to entirely turn off caching: https://www.drupal.org/node/2598914
 
 ### Breakpoints and Responsive Images
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -168,15 +168,9 @@ class RoboFile extends Tasks {
    * @return array
    *   List of directories.
    */
-  protected function monitoredDirectories(): array {
+  protected function monitoredThemeDirectories(): array {
     return [
       self::THEME_BASE . '/src',
-      // Look in the twig files.
-      self::THEME_BASE . '/templates',
-      // A preprocess function might inject a class.
-      self::THEME_BASE . '/server_theme.theme',
-      // Custom module and the Style guide may have needed classes.
-      'web/modules/custom/',
     ];
   }
 
@@ -186,7 +180,7 @@ class RoboFile extends Tasks {
   public function themeWatch(): void {
     $this->say('Compiling and watching (optimized).');
     $this->doThemeCompile(TRUE);
-    foreach ($this->monitoredDirectories() as $directory) {
+    foreach ($this->monitoredThemeDirectories() as $directory) {
       $this->taskWatch()
         ->monitor(
           $directory,
@@ -204,7 +198,7 @@ class RoboFile extends Tasks {
   public function themeWatchDebug(): void {
     $this->say('Compiling and watching (non-optimized).');
     $this->doThemeCompile();
-    foreach ($this->monitoredDirectories() as $directory) {
+    foreach ($this->monitoredThemeDirectories() as $directory) {
       $this->taskWatch()
         ->monitor(
           $directory,


### PR DESCRIPTION
Reverts Gizra/drupal-starter#330

`theme:watch` is now too slow - and runs all copying, even if just the CSS has changed. 

/cc @dipakmdhrm 