### PR TITLE
Gitignore .orig and .rej

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ web/sites/all/drush
 
 # PHPunit cache file
 .phpunit.result.cache
+
+# Patching leftover.
+*.orig
+*.rej


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/master/.gitignore#L136

`*.orig` is widespread, `*.rej` not so much, but:

https://github.com/sonyxperiadev/kernel/blob/aosp/LA.UM.9.14.r1/.gitignore#L126
