### PR TITLE
Prevent button from growing

### DIFF
--- a/web/themes/custom/server_theme/templates/server-theme-button.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-button.html.twig
@@ -8,7 +8,7 @@
 {% endmacro %}
 
 {% set classes = [
-  'flex flex-row items-center space-x-6 rounded-lg px-6 py-3 text-xl border-2 border-blue-500 hover:bg-blue-600 w-min',
+  'flex flex-row items-center space-x-6 rounded-lg px-6 py-3 text-xl border-2 border-blue-500 hover:bg-blue-600 w-fit',
   is_primary ? 'bg-blue-500 text-white' : 'text-blue-900 bg-white hover:text-white',
 ] | join(' ') | trim %}
 

--- a/web/themes/custom/server_theme/templates/server-theme-button.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-button.html.twig
@@ -8,7 +8,7 @@
 {% endmacro %}
 
 {% set classes = [
-  'flex flex-row items-center space-x-6 rounded-lg px-6 py-3 text-xl border-2 border-blue-500 hover:bg-blue-600',
+  'flex flex-row items-center space-x-6 rounded-lg px-6 py-3 text-xl border-2 border-blue-500 hover:bg-blue-600 w-min',
   is_primary ? 'bg-blue-500 text-white' : 'text-blue-900 bg-white hover:text-white',
 ] | join(' ') | trim %}
 


### PR DESCRIPTION
When inside `flex` without this change, the button would become full width. Unless it's already wrapped with `w-full`


| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/125707/202216408-0acb0f7f-a0f4-49b1-b335-dc558e9cfa56.png) | ![image](https://user-images.githubusercontent.com/125707/202216344-4a8c5484-2c3f-4b95-8b14-e0f6fffa09c1.png) |
