### PR TITLE
Hero responsive images should be "Focal point scale and crop"

### DIFF
--- a/config/sync/image.style.hero_lg_1x.yml
+++ b/config/sync/image.style.hero_lg_1x.yml
@@ -1,15 +1,17 @@
 uuid: 5f5fe99e-b743-4183-8ae2-8fe599998ad4
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_lg_1x
 label: 'Hero lg 1x (1280x400)'
 effects:
-  48c88dc0-be72-47c7-bab1-65aa448b41c7:
-    uuid: 48c88dc0-be72-47c7-bab1-65aa448b41c7
-    id: image_scale_and_crop
-    weight: 1
+  fb11a935-d494-4df8-aa8b-6525a4e1214f:
+    uuid: fb11a935-d494-4df8-aa8b-6525a4e1214f
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 1280
       height: 400
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_lg_2x.yml
+++ b/config/sync/image.style.hero_lg_2x.yml
@@ -1,15 +1,17 @@
 uuid: f49373ba-be1f-451c-9e43-83967dfd2b15
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_lg_2x
 label: 'Hero lg 2x (2560x800)'
 effects:
-  7d7f962b-8936-488d-8046-09e6b8dadec5:
-    uuid: 7d7f962b-8936-488d-8046-09e6b8dadec5
-    id: image_scale_and_crop
-    weight: 1
+  2964706b-2018-47e7-bfa0-328d35a1a0d0:
+    uuid: 2964706b-2018-47e7-bfa0-328d35a1a0d0
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 2560
       height: 800
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_md_1x.yml
+++ b/config/sync/image.style.hero_md_1x.yml
@@ -1,15 +1,17 @@
 uuid: 648a4e38-ac88-448c-93d0-d7c8893c0215
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_md_1x
 label: 'Hero md 1x (1024x320)'
 effects:
-  c4fdd4b9-e9b5-49f8-9f34-d6dff5c928de:
-    uuid: c4fdd4b9-e9b5-49f8-9f34-d6dff5c928de
-    id: image_scale_and_crop
-    weight: 1
+  28faf958-81d3-4b8b-88e1-84c6781844b4:
+    uuid: 28faf958-81d3-4b8b-88e1-84c6781844b4
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 1024
       height: 320
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_md_2x.yml
+++ b/config/sync/image.style.hero_md_2x.yml
@@ -1,15 +1,17 @@
 uuid: d8b9c4ce-5986-44a6-a0bb-a8f92fbaa0c8
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_md_2x
 label: 'Hero md 2x (2048x640)'
 effects:
-  032b723f-659e-4c7b-a4b8-578e064dd822:
-    uuid: 032b723f-659e-4c7b-a4b8-578e064dd822
-    id: image_scale_and_crop
-    weight: 1
+  282fd3ba-ff15-4121-91d0-9ce30ac48108:
+    uuid: 282fd3ba-ff15-4121-91d0-9ce30ac48108
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 2048
       height: 640
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_mobile_1x.yml
+++ b/config/sync/image.style.hero_mobile_1x.yml
@@ -1,15 +1,17 @@
 uuid: c878eccf-1361-4db6-b785-89b3f5805b74
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_mobile_1x
 label: 'Hero mobile 1x (640x200)'
 effects:
-  abb1c492-b52a-4402-8163-f2d0847ed8f5:
-    uuid: abb1c492-b52a-4402-8163-f2d0847ed8f5
-    id: image_scale_and_crop
-    weight: 1
+  20d79599-f457-4502-aaf1-9353f50588f7:
+    uuid: 20d79599-f457-4502-aaf1-9353f50588f7
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 640
       height: 200
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_mobile_2x.yml
+++ b/config/sync/image.style.hero_mobile_2x.yml
@@ -1,15 +1,17 @@
 uuid: 78b479d6-b687-4998-98bc-5da77b410926
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_mobile_2x
 label: 'Hero mobile 2x (1280x400)'
 effects:
-  c37a1cd3-8aaf-4c37-801a-e13a8b201b91:
-    uuid: c37a1cd3-8aaf-4c37-801a-e13a8b201b91
-    id: image_scale_and_crop
-    weight: 1
+  81b089b0-c819-4b35-83d8-db2e3529d11c:
+    uuid: 81b089b0-c819-4b35-83d8-db2e3529d11c
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 1280
       height: 400
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_sm_1x.yml
+++ b/config/sync/image.style.hero_sm_1x.yml
@@ -1,15 +1,17 @@
 uuid: 18e0b01f-b218-469b-a027-3fce68860bd4
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_sm_1x
 label: 'Hero sm 1x (768x240)'
 effects:
-  b07c4661-b39a-43a0-84aa-0571c2128b57:
-    uuid: b07c4661-b39a-43a0-84aa-0571c2128b57
-    id: image_scale_and_crop
-    weight: 1
+  99e6f34e-484a-4850-acd2-7fbae13a188d:
+    uuid: 99e6f34e-484a-4850-acd2-7fbae13a188d
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 768
       height: 240
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_sm_2x.yml
+++ b/config/sync/image.style.hero_sm_2x.yml
@@ -1,15 +1,17 @@
 uuid: b3d69294-cb3b-4ee9-b1f1-e2f5d8d6e615
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_sm_2x
 label: 'Hero sm 2x (1536x480)'
 effects:
-  edc127f3-3acc-4c47-ae83-29065bfc606d:
-    uuid: edc127f3-3acc-4c47-ae83-29065bfc606d
-    id: image_scale_and_crop
-    weight: 1
+  07039862-9312-4a6e-ae21-b46e5438e9f8:
+    uuid: 07039862-9312-4a6e-ae21-b46e5438e9f8
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 1536
       height: 480
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_xl_1x.yml
+++ b/config/sync/image.style.hero_xl_1x.yml
@@ -1,15 +1,17 @@
 uuid: 422a5bac-ee50-4fdf-8e3b-c6139adb0542
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_xl_1x
 label: 'Hero xl 1x (1536x466)'
 effects:
-  82235160-5364-440f-8279-e89171f22f4e:
-    uuid: 82235160-5364-440f-8279-e89171f22f4e
-    id: image_scale_and_crop
-    weight: 1
+  78b620b9-c83e-442f-a567-69ac44e15f6a:
+    uuid: 78b620b9-c83e-442f-a567-69ac44e15f6a
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 1536
       height: 466
-      anchor: center-center
+      crop_type: focal_point

--- a/config/sync/image.style.hero_xl_2x.yml
+++ b/config/sync/image.style.hero_xl_2x.yml
@@ -1,15 +1,17 @@
 uuid: 2e9ba4ee-cf1c-47e1-8187-6588bcfcc786
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: hero_xl_2x
 label: 'Hero xl 2x (3072x932)'
 effects:
-  674d2c07-bf11-4bef-91fe-6558813da8df:
-    uuid: 674d2c07-bf11-4bef-91fe-6558813da8df
-    id: image_scale_and_crop
-    weight: 1
+  846a8234-1f8f-4949-bee1-475117f1dd9d:
+    uuid: 846a8234-1f8f-4949-bee1-475117f1dd9d
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 3072
       height: 932
-      anchor: center-center
+      crop_type: focal_point


### PR DESCRIPTION
#357 

### Update
- Replace 'Scale and Crop' with 'Focal Point image and crop' in all image styles.

10 image styles with 'Scale and Crop' before change|No image styles with 'Scale and Crop' after change
-|-
![before](https://user-images.githubusercontent.com/4610167/205899558-bdf046e6-adf3-47b2-aee7-641b714e063b.png)|![after](https://user-images.githubusercontent.com/4610167/205899543-061e3a3b-be27-49a2-ab77-715a9a140851.png)


**TB:1h**