### PR TITLE
Ensure rounded corners fit to their content

### DIFF
--- a/web/themes/custom/server_theme/templates/server-theme-container-rounded-corners-big.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-rounded-corners-big.html.twig
@@ -1,3 +1,3 @@
-<div class="rounded-lg overflow-hidden">
+<div class="rounded-lg overflow-hidden w-fit">
   {{ items }}
 </div>


### PR DESCRIPTION
This ensures the rounded-corners div wrapper nicely wraps the image, otherwise the div stretches full width, and only the top/bottom left corners are rounded.

No `w-fit`|With `w-fit`
-|-
![image](https://user-images.githubusercontent.com/24897663/207428220-a1450eed-4983-4e87-b425-54fb61631477.png)|![image](https://user-images.githubusercontent.com/24897663/207428303-07a10f7a-a201-4100-8231-f2b21ac21bc7.png)

Difference: Top-right, bottom-right corners are rounded on a portrait image
