### PR TITLE
Replaced buggy boolean comparisons to ?? operators.

### DIFF
--- a/web/themes/custom/server_theme/templates/server-theme-carousel-base.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-carousel-base.html.twig
@@ -1,12 +1,12 @@
 {{ attach_library('server_theme/slick') }}
 {% if items is not empty %}
   <div class="carousel-wrapper"
-       data-carousel-dots="{{ dots|default('false') }}"
-       data-carousel-arrows="{{ arrows|default('false') }}"
-       data-carousel-fixed-width-on-mobile="{{ fixed_width_on_mobile|default('false') }}"
-       data-carousel-center-mode-mobile="{{ center_mode_mobile|default('false') }}"
-       data-carousel-responsive="{{ responsive|default('true') }}"
-       data-carousel-single-slide="{{ single_slide|default('false') }}"
+       data-carousel-dots="{{ dots ?? 'false' }}"
+       data-carousel-arrows="{{ arrows ?? 'false' }}"
+       data-carousel-fixed-width-on-mobile="{{ fixed_width_on_mobile ?? 'false' }}"
+       data-carousel-center-mode-mobile="{{ center_mode_mobile ?? 'false' }}"
+       data-carousel-responsive="{{ responsive ?? 'true' }}"
+       data-carousel-single-slide="{{ single_slide ?? 'false' }}"
        data-slides-to-scroll="{{ slides_to_scroll|default('1') }}"
        {% if slides_tablet %}data-slides-tablet="{{ slides_tablet }}"{% endif %}
        {% if slides_laptop %}data-slides-laptop="{{ slides_laptop }}"{% endif %}


### PR DESCRIPTION
Per [twig documentation](https://twig.symfony.com/doc/2.x/filters/default.html)

`Using the default filter on a boolean variable might trigger unexpected behavior, as false is treated as an empty value. Consider using ?? instead:`

The only buggy expression was the comparison of the `responsive` variable, but I have replaced all of these initializations anyway.