### PR TITLE
Split `wrapTextDecorations` to smaller methods

### DIFF
--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -190,7 +190,8 @@ trait ElementWrapTrait {
    * @param bool $is_italic
    *   TRUE to make the text italic.
    * @param string|null $mobile_font_size
-   *   The font size for mobile. Can be 'xs', 'sm' or 'lg'.
+   *   The font size for mobile. Can be 'xs', 'sm' or 'lg'. On 
+   *   Twig, we'll take care of making the font size responsive.
    *   Defaults to NULL, which will not change the font size.
    *
    * @return array

--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -184,8 +184,7 @@ trait ElementWrapTrait {
    * @param array|string|\Drupal\Core\StringTranslation\TranslatableMarkup $element
    *   The render array, string or a TranslatableMarkup object.
    * @param string $font_weight
-   *   Font weight of the text. Can be 'thin', 'extralight', 'light',
-   *   'normal', 'medium', 'semibold', 'bold', 'extrabold' or 'black'.
+   *   Font weight of the text. Can be 'normal', 'medium', 'semibold', 'bold'.
    * @param bool $is_underline
    *   TRUE to make it text underlined.
    * @param bool $is_italic

--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -190,7 +190,7 @@ trait ElementWrapTrait {
    * @param bool $is_italic
    *   TRUE to make the text italic.
    * @param string|null $mobile_font_size
-   *   The font size for mobile. Can be 'xs', 'sm' or 'lg'. On 
+   *   The font size for mobile. Can be 'xs', 'sm' or 'lg'. On
    *   Twig, we'll take care of making the font size responsive.
    *   Defaults to NULL, which will not change the font size.
    *

--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -181,20 +181,26 @@ trait ElementWrapTrait {
   /**
    * Wrap an element with text decorations.
    *
-   * @param array|string $element
-   *   The render array or string.
-   * @param bool $is_bold
-   *   TRUE to make it text bold.
+   * @param array|string|\Drupal\Core\StringTranslation\TranslatableMarkup $element
+   *   The render array, string or a TranslatableMarkup object.
+   * @param string $font_weight
+   *   Font weight of the text. Can be 'thin', 'extralight', 'light',
+   *   'normal', 'medium', 'semibold', 'bold', 'extrabold' or 'black'.
    * @param bool $is_underline
    *   TRUE to make it text underlined.
-   * @param string|null $font_size
-   *   The font size. Can be `sm`, `lg` or `xl`. Defaults to NULL, which will
-   *   not change the font size.
+   * @param bool $is_italic
+   *   TRUE to make the text italic.
+   * @param string|null $mobile_font_size
+   *   The font size for mobile. Can be 'xs', 'sm' or 'lg'.
+   *   Defaults to NULL, which will not change the font size.
    *
    * @return array
    *   Render array.
    */
-  protected function wrapTextDecorations(array|string $element, bool $is_bold, bool $is_underline, string $font_size = NULL): array {
+  protected function wrapTextDecorations(array|string|TranslatableMarkup $element, string $font_weight = 'normal', bool $is_underline = FALSE, bool $is_italic = FALSE, string $mobile_font_size = NULL): array {
+    if (is_array($element)) {
+      $element = $this->filterEmptyElements($element);
+    }
     if (empty($element)) {
       // Element is empty, so no need to wrap it.
       return [];
@@ -203,9 +209,10 @@ trait ElementWrapTrait {
     return [
       '#theme' => 'server_theme_text_decorations',
       '#element' => $element,
-      '#is_bold' => $is_bold,
+      '#font_weight' => $font_weight,
       '#is_underline' => $is_underline,
-      '#font_size' => $font_size,
+      '#is_italic' => $is_italic,
+      '#font_size' => $mobile_font_size,
     ];
   }
 

--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -181,7 +181,7 @@ trait ElementWrapTrait {
   /**
    * Wrap an element with text decorations.
    *
-   * @param array|string|\Drupal\Core\StringTranslation\TranslatableMarkup $element
+   * @param array|string $element
    *   The render array, string or a TranslatableMarkup object.
    * @param string $font_weight
    *   Font weight of the text. Can be 'normal', 'medium', 'semibold', 'bold'.
@@ -196,7 +196,7 @@ trait ElementWrapTrait {
    * @return array
    *   Render array.
    */
-  protected function wrapTextDecorations(array|string|TranslatableMarkup $element, string $font_weight = 'normal', bool $is_underline = FALSE, bool $is_italic = FALSE, string $mobile_font_size = NULL): array {
+  protected function wrapTextDecorations(array|string $element, string $font_weight = 'normal', bool $is_underline = FALSE, bool $is_italic = FALSE, string $mobile_font_size = NULL): array {
     if (is_array($element)) {
       $element = $this->filterEmptyElements($element);
     }

--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -196,7 +196,7 @@ trait ElementWrapTrait {
    * @return array
    *   Render array.
    */
-  protected function wrapTextDecorations(array|string $element, string $font_weight = 'normal', bool $is_underline = FALSE, bool $is_italic = FALSE, string $mobile_font_size = NULL): array {
+  protected function wrapTextDecorations(array|string $element, string $font_weight = NULL, bool $is_underline = FALSE, bool $is_italic = FALSE, string $mobile_font_size = NULL): array {
     if (is_array($element)) {
       $element = $this->filterEmptyElements($element);
     }

--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\server_general;
 
 use Drupal\Core\Render\Element;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Helper method for wrapping an element.
@@ -181,7 +182,7 @@ trait ElementWrapTrait {
   /**
    * Wrap an element with text decorations.
    *
-   * @param array|string $element
+   * @param array|string|\Drupal\Core\StringTranslation\TranslatableMarkup $element
    *   The render array, string or a TranslatableMarkup object.
    * @param string $font_weight
    *   Font weight of the text. Can be 'normal', 'medium', 'semibold', 'bold'.
@@ -197,7 +198,7 @@ trait ElementWrapTrait {
    * @return array
    *   Render array.
    */
-  protected function wrapTextDecorations(array|string $element, string $font_weight = NULL, bool $is_underline = FALSE, bool $is_italic = FALSE, string $mobile_font_size = NULL): array {
+  protected function wrapTextDecorations(array|string|TranslatableMarkup $element, string $font_weight = NULL, bool $is_underline = FALSE, bool $is_italic = FALSE, string $mobile_font_size = NULL): array {
     if (is_array($element)) {
       $element = $this->filterEmptyElements($element);
     }

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
@@ -80,7 +80,7 @@ class NodeNews extends NodeViewBuilderAbstract {
     $timestamp = $this->getFieldOrCreatedTimestamp($entity, 'field_publish_date');
     $element = IntlDate::formatPattern($timestamp, 'long');
     // Make text bigger.
-    $elements[] = $this->wrapTextDecorations($element, FALSE, FALSE, 'lg');
+    $elements[] = $this->wrapTextDecorations($element, 'normal', FALSE, FALSE, 'sm');
 
     $elements = $this->wrapContainerVerticalSpacing($elements);
     return $this->wrapContainerNarrow($elements);

--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -243,7 +243,7 @@ function server_theme_theme() {
     'variables' => [
       // The element to wrap.
       'element' => [],
-      'is_bold' => NULL,
+      'font_weight' => NULL,
       'is_underline' => NULL,
       // Can either be `sm`, `lg` or `xl`. Defaults to NULL, which will not
       // change the font size.

--- a/web/themes/custom/server_theme/templates/server-theme-text-decorations.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-text-decorations.html.twig
@@ -1,17 +1,39 @@
-{% if font_size == 'sm' %}
-  {% set font_size_class = 'text-sm' %}
+{% if font_size == 'xs' %}
+  {% set font_size_classes = 'text-xs md:text-sm lg:text-base' %}
+{% elseif font_size == 'sm' %}
+  {% set font_size_classes = 'text-sm md:text-base lg:text-lg' %}
 {% elseif font_size == 'lg' %}
-  {% set font_size_class = 'text-lg' %}
-{% elseif font_size == 'xl' %}
-  {% set font_size_class = 'text-xl' %}
+  {% set font_size_classes = 'text-lg md:text-xl lg:text-2xl' %}
+{% endif %}
+
+{% if font_weight == 'thin' %}
+  {% set font_weight_class = 'font-thin' %}
+{% elseif font_weight == 'extralight' %}
+  {% set font_weight_class = 'font-extralight' %}
+{% elseif font_weight == 'light' %}
+  {% set font_weight_class = 'font-light' %}
+{% elseif font_weight == 'normal' %}
+  {% set font_weight_class = 'font-normal' %}
+{% elseif font_weight == 'medium' %}
+  {% set font_weight_class = 'font-medium' %}
+{% elseif font_weight == 'semibold' %}
+  {% set font_weight_class = 'font-semibold' %}
+{% elseif font_weight == 'bold' %}
+  {% set font_weight_class = 'font-bold' %}
+{% elseif font_weight == 'extrabold' %}
+  {% set font_weight_class = 'font-extrabold' %}
+{% elseif font_weight == 'black' %}
+  {% set font_weight_class = 'font-black' %}
 {% endif %}
 
 {% set classes = [
-  is_bold ? 'font-bold',
+  font_weight_class,
   is_underline ? 'underline',
-  font_size_class,
+  is_italic ? 'italic',
+  font_size_classes,
 ] | join(' ') | trim %}
 
 <div class="{{ classes }}">
   {{ element }}
 </div>
+

--- a/web/themes/custom/server_theme/templates/server-theme-text-decorations.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-text-decorations.html.twig
@@ -6,13 +6,7 @@
   {% set font_size_classes = 'text-lg md:text-xl lg:text-2xl' %}
 {% endif %}
 
-{% if font_weight == 'thin' %}
-  {% set font_weight_class = 'font-thin' %}
-{% elseif font_weight == 'extralight' %}
-  {% set font_weight_class = 'font-extralight' %}
-{% elseif font_weight == 'light' %}
-  {% set font_weight_class = 'font-light' %}
-{% elseif font_weight == 'normal' %}
+{% if font_weight == 'normal' %}
   {% set font_weight_class = 'font-normal' %}
 {% elseif font_weight == 'medium' %}
   {% set font_weight_class = 'font-medium' %}
@@ -20,10 +14,6 @@
   {% set font_weight_class = 'font-semibold' %}
 {% elseif font_weight == 'bold' %}
   {% set font_weight_class = 'font-bold' %}
-{% elseif font_weight == 'extrabold' %}
-  {% set font_weight_class = 'font-extrabold' %}
-{% elseif font_weight == 'black' %}
-  {% set font_weight_class = 'font-black' %}
 {% endif %}
 
 {% set classes = [


### PR DESCRIPTION
- Changed wrapTextDecoration to use string font_weight parameter.
- mobile_font_size is responsive now.