### PR TITLE
Prepare menu links recursively.

### DIFF
--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -421,14 +421,44 @@ function server_theme_prepare_block(string $bid, array $config): array {
  * @return array
  *   Menu links array.
  */
+
+/**
+ * Prepare menu links.
+ *
+ * @param string $menu_name
+ *   Menu name.
+ *
+ * @return array
+ *   Menu links array.
+ */
 function server_theme_prepare_menu_links(string $menu_name) {
   $menu_tree = \Drupal::service('menu.link_tree');
   // Build the typical default set of menu tree parameters.
   $parameters = $menu_tree->getCurrentRouteMenuTreeParameters($menu_name);
   // Load the tree based on this set of parameters.
   $tree = $menu_tree->load($menu_name, $parameters);
+  // Build a hierarchical menu and return that.
+  return _server_theme_extract_menu_level($tree);
+}
+
+/**
+ * Extracts menu links recursively.
+ *
+ * @param array $tree
+ *   Menu name.
+ *
+ * @return array
+ *   Menu links array.
+ */
+function _server_theme_extract_menu_level(array $tree) {
   $menu = [];
+  /** @var \Drupal\Core\Menu\MenuLinkTreeElement $element */
   foreach ($tree as $element) {
+    // If we have a subtree, extract that.
+    $child_links = NULL;
+    if (!empty($element->subtree)) {
+      $child_links = _server_theme_extract_menu_level($element->subtree);
+    }
     $menu_link = $element->link;
     if (!$menu_link->isEnabled()) {
       continue;
@@ -444,9 +474,9 @@ function server_theme_prepare_menu_links(string $menu_name) {
     $menu[$weight] = [
       'title' => $menu_link->getTitle(),
       'href' => $url->toString(),
+      'children' => $child_links,
     ];
   }
   ksort($menu);
-
   return $menu;
 }


### PR DESCRIPTION
I think we might want to port this from another project

Single level menu links still display properly:

![image](https://user-images.githubusercontent.com/3536805/208052477-aae5a9c1-52a3-46c3-96bf-3197fd39c6af.png)
