### PR TITLE
Fix default body field machine name method argument.

### DIFF
--- a/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
+++ b/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
@@ -25,7 +25,7 @@ trait ProcessedTextBuilderTrait {
    * @return array
    *   Render array.
    */
-  protected function buildProcessedText(FieldableEntityInterface $entity, string $field = 'field_body', bool $wrap_prose = TRUE) : array {
+  protected function buildProcessedText(FieldableEntityInterface $entity, string $field = 'body', bool $wrap_prose = TRUE) : array {
     if (!$entity->hasField($field) || $entity->get($field)->isEmpty()) {
       // Field is empty or doesn't exist.
       return [];


### PR DESCRIPTION
Default value for $field argument in method buildProcessedText() is wrong. The @param comment has correct value. Instead of "field_body" it should default to "body".