### PR TITLE
Improve array filtering for element wrap.

### DIFF
--- a/web/modules/custom/server_general/src/ElementWrapTrait.php
+++ b/web/modules/custom/server_general/src/ElementWrapTrait.php
@@ -479,7 +479,13 @@ trait ElementWrapTrait {
       // Nothing to do here.
       return $element;
     }
-    if (count(Element::properties($element))) {
+
+    // Filter out the empty keys in the element.
+    $element_with_keys = array_filter(
+      $element, fn ($key) => isset($key[0]), ARRAY_FILTER_USE_KEY
+    );
+
+    if (count(Element::properties($element_with_keys))) {
       // Element has top level properties beginning with #.
       // Do not filter.
       return $element;

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralElementWrapTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralElementWrapTest.php
@@ -28,9 +28,11 @@ class ServerGeneralElementWrapTest extends ExistingSiteBase {
     // Non-nested array.
     $element = [
       '#foo' => FALSE,
+      '' => FALSE,
     ];
     $expected = [
       '#foo' => FALSE,
+      '' => FALSE,
     ];
     $result = $this->filterEmptyElements($element);
     $this->assertEquals($expected, $result);
@@ -40,10 +42,12 @@ class ServerGeneralElementWrapTest extends ExistingSiteBase {
     $element = [
       '#foo' => FALSE,
       0 => [],
+      '' => [],
     ];
     $expected = [
       '#foo' => FALSE,
       0 => [],
+      '' => [],
     ];
     $result = $this->filterEmptyElements($element);
     $this->assertEquals($expected, $result);
@@ -52,6 +56,7 @@ class ServerGeneralElementWrapTest extends ExistingSiteBase {
     $element = [
       0 => [],
       1 => [],
+      '' => [],
     ];
     $expected = [];
     $result = $this->filterEmptyElements($element);
@@ -61,43 +66,10 @@ class ServerGeneralElementWrapTest extends ExistingSiteBase {
     $element = [
       0 => [],
       1 => ['#foo' => FALSE],
-    ];
-    $expected = [
-      1 => ['#foo' => FALSE],
-    ];
-    $result = $this->filterEmptyElements($element);
-    $this->assertEquals($expected, $result);
-
-    // Non-nested array with empty key.
-    $element = [
-      '' => FALSE,
-    ];
-    $expected = [];
-    $result = $this->filterEmptyElements($element);
-    $this->assertEquals($expected, $result);
-
-    // Mix of non-nested and nested array with empty key.
-    // As it has top level `#` we shouldn't filter it at all.
-    $element = [
-      '#foo' => FALSE,
       '' => [],
     ];
     $expected = [
-      '#foo' => FALSE,
-      '' => [],
-    ];
-    $result = $this->filterEmptyElements($element);
-    $this->assertEquals($expected, $result);
-
-    // Nested array with empty key and some existing elements.
-    $element = [
-      0 => [],
       1 => ['#foo' => FALSE],
-      '' => ['#foo' => FALSE],
-    ];
-    $expected = [
-      1 => ['#foo' => FALSE],
-      '' => ['#foo' => FALSE],
     ];
     $result = $this->filterEmptyElements($element);
     $this->assertEquals($expected, $result);

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralElementWrapTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralElementWrapTest.php
@@ -67,6 +67,40 @@ class ServerGeneralElementWrapTest extends ExistingSiteBase {
     ];
     $result = $this->filterEmptyElements($element);
     $this->assertEquals($expected, $result);
+
+    // Non-nested array with empty key.
+    $element = [
+      '' => FALSE,
+    ];
+    $expected = [];
+    $result = $this->filterEmptyElements($element);
+    $this->assertEquals($expected, $result);
+
+    // Mix of non-nested and nested array with empty key.
+    // As it has top level `#` we shouldn't filter it at all.
+    $element = [
+      '#foo' => FALSE,
+      '' => [],
+    ];
+    $expected = [
+      '#foo' => FALSE,
+      '' => [],
+    ];
+    $result = $this->filterEmptyElements($element);
+    $this->assertEquals($expected, $result);
+
+    // Nested array with empty key and some existing elements.
+    $element = [
+      0 => [],
+      1 => ['#foo' => FALSE],
+      '' => ['#foo' => FALSE],
+    ];
+    $expected = [
+      1 => ['#foo' => FALSE],
+      '' => ['#foo' => FALSE],
+    ];
+    $result = $this->filterEmptyElements($element);
+    $this->assertEquals($expected, $result);
   }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralElementWrapTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralElementWrapTest.php
@@ -28,10 +28,12 @@ class ServerGeneralElementWrapTest extends ExistingSiteBase {
     // Non-nested array.
     $element = [
       '#foo' => FALSE,
+      0 => FALSE,
       '' => FALSE,
     ];
     $expected = [
       '#foo' => FALSE,
+      0 => FALSE,
       '' => FALSE,
     ];
     $result = $this->filterEmptyElements($element);


### PR DESCRIPTION
If element has empty key, Element::Properties throws error: Uninitialized string offset: 0 in Drupal\Core\Render\Element::property(). To fix this issue, before passing it to Properties method, filtering out the empty keys.