### PR TITLE
Added bottom padding to .slick-track.

### DIFF
--- a/web/themes/custom/server_theme/src/pcss/slick.pcss
+++ b/web/themes/custom/server_theme/src/pcss/slick.pcss
@@ -45,8 +45,9 @@
   @apply mt-0 lg:-mx-5 w-full lg:w-auto;
 }
 
+// We need some bottom padding to display box shadow.
 .slick-track {
-  @apply flex;
+  @apply flex pb-1;
 
   .slick-slide {
     @apply flex h-auto float-none;


### PR DESCRIPTION
I have added a bottom padding to the carousel, otherwise box-shadow might get truncated.