### PR TITLE
Preserve "Drupal" in js minify

### DIFF
--- a/web/themes/custom/server_theme/.minify.json
+++ b/web/themes/custom/server_theme/.minify.json
@@ -1,0 +1,7 @@
+{
+  "js": {
+    "mangle": {
+      "reserved": ["Drupal"]
+    }
+  }
+}


### PR DESCRIPTION
This is because Locale module looks for `Drupal.t` in order to decide whether to load the string translation for a phrase. (see `_locale_parse_js_file`)

If `Drupal.t('Read more')` is mangled to something else during minification, like `a.t('Read more')` then locale doesn't add the string translation anymore for that phrase.