### PR TITLE
Copy .htaccess in public files directory during deployment

### DIFF
--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -221,6 +221,9 @@ trait DeploymentTrait {
     // site-specific modifications belong to settings.php.
     $this->_exec("cp web/sites/default/settings.pantheon.php $pantheon_directory/web/sites/default/settings.php");
 
+    // Copy the updated .htaccess file.
+    $this->_exec("cp web/sites/default/files/.htaccess $pantheon_directory/web/sites/default/files/.htaccess");
+
     // Flag the current version in the artifact repo.
     file_put_contents($deployment_version_path, $current_version);
 


### PR DESCRIPTION

- sites/default directory is excluded from deployment, but .htaccess file needs to be copied to get rid of 'Insecure public files directory' message in reports.

TB: 0.2h