### PR TITLE
Reverting .htaccess copy code

### DIFF
--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -221,9 +221,6 @@ trait DeploymentTrait {
     // site-specific modifications belong to settings.php.
     $this->_exec("cp web/sites/default/settings.pantheon.php $pantheon_directory/web/sites/default/settings.php");
 
-    // Copy the updated .htaccess file.
-    $this->_exec("cp web/sites/default/files/.htaccess $pantheon_directory/web/sites/default/files/.htaccess");
-
     // Flag the current version in the artifact repo.
     file_put_contents($deployment_version_path, $current_version);
 


### PR DESCRIPTION
In [Gizra/unsdg/#3588](https://github.com/Gizra/unsdg/issues/3588) it turns out we cannot copy the .htaccess file from code.

