### PR TITLE
Smart trim and `buildProcessedTextTrimmed` for card teasers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "drupal/search_api": "^1.18",
         "drupal/select2": "^1.13",
         "drupal/simple_sitemap": "^4",
+        "drupal/smart_trim": "^2.0",
         "drupal/stage_file_proxy": "^1.1",
         "drush/drush": "^11",
         "npm-asset/select2": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c77526403a135962b83360800add280",
+    "content-hash": "38b7398e1b75469e923fc2317a16b04a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3567,6 +3567,65 @@
             "support": {
                 "source": "https://cgit.drupalcode.org/simple_sitemap",
                 "issues": "https://drupal.org/project/issues/simple_sitemap"
+            }
+        },
+        {
+            "name": "drupal/smart_trim",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/smart_trim.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/smart_trim-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "d917ad4d78b50cf535f3a292a2e09cc73b87bf4f"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10",
+                "drupal/token": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1666374010",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Casias (markie)",
+                    "homepage": "https://www.drupal.org/u/markie",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "newsignature",
+                    "homepage": "https://www.drupal.org/user/765518"
+                },
+                {
+                    "name": "ultimike",
+                    "homepage": "https://www.drupal.org/user/51132"
+                },
+                {
+                    "name": "volkswagenchick",
+                    "homepage": "https://www.drupal.org/user/3332522"
+                }
+            ],
+            "description": "Provides a more robust alternative to 'summary or trimmed' textfield format.",
+            "homepage": "https://drupal.org/project/smart_trim",
+            "support": {
+                "source": "https://git.drupalcode.org/project/smart_trim",
+                "issues": "https://drupal.org/project/issues/smart_trim"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -69,6 +69,7 @@ module:
   server_style_guide: 0
   shortcut: 0
   simple_sitemap: 0
+  smart_trim: 0
   system: 0
   taxonomy: 0
   text: 0

--- a/web/modules/custom/server_general/src/CardTrait.php
+++ b/web/modules/custom/server_general/src/CardTrait.php
@@ -50,7 +50,7 @@ trait CardTrait {
     $elements[] = $this->wrapTextResponsiveFontSize($element, 'sm');
 
     // Date.
-    $element = ['#markup' => IntlDate::formatPattern($timestamp, 'short')];
+    $element = IntlDate::formatPattern($timestamp, 'short');
     $element = $this->wrapTextColor($element, 'gray');
     $elements[] = $this->wrapTextResponsiveFontSize($element, 'sm');
 

--- a/web/modules/custom/server_general/src/CardTrait.php
+++ b/web/modules/custom/server_general/src/CardTrait.php
@@ -60,7 +60,7 @@ trait CardTrait {
     $elements[] = $this->wrapTextFontWeight($element, 'bold');
 
     // Body teaser.
-    $elements[] = $this->wrapTextLineClamp($summary, 4);
+    $elements[] = $summary;
 
     return $this->buildCardLayoutWithImage($url, $image, $elements);
   }

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
@@ -150,7 +150,8 @@ class NodeNews extends NodeViewBuilderAbstract {
     $image = $media instanceof MediaInterface ? $this->buildImageStyle($media, 'card', 'field_media_image') : [];
     $title = $entity->label();
     $url = $entity->toUrl();
-    $summary = $this->buildProcessedText($entity, 'field_body', FALSE);
+    $summary = $this->buildProcessedTextTrimmed($entity, 'field_body');
+
     $timestamp = $this->getFieldOrCreatedTimestamp($entity, 'field_publish_date');
 
     $element = $this->buildCardWithImageForNews(

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
@@ -151,7 +151,6 @@ class NodeNews extends NodeViewBuilderAbstract {
     $title = $entity->label();
     $url = $entity->toUrl();
     $summary = $this->buildProcessedTextTrimmed($entity, 'field_body');
-
     $timestamp = $this->getFieldOrCreatedTimestamp($entity, 'field_publish_date');
 
     $element = $this->buildCardWithImageForNews(

--- a/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
+++ b/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
@@ -34,15 +34,6 @@ trait ProcessedTextBuilderTrait {
     // Hide the label.
     $options = ['label' => 'hidden'];
 
-    if ($trim_length) {
-      $options += [
-        'type' => 'smart_trim',
-        'settings' => [
-          'trim_length' => $trim_length,
-        ],
-      ];
-    }
-
     $element = $entity->get($field)->view($options);
     return $wrap_prose ? $this->wrapProseText($element) : $element;
   }

--- a/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
+++ b/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
@@ -53,6 +53,9 @@ trait ProcessedTextBuilderTrait {
    * @param bool $strip_tags
    *   Determine if output should be stripped of most tags, and keep only a
    *   smaller set of tags. Defaults to TRUE.
+   * @param int $line_clamp
+   *   If set, `wrapTextLineClamp` will be used on the trimmed text. Defaults to
+   *   4.
    *
    * @return array
    *   Render array.

--- a/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
+++ b/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
@@ -34,7 +34,66 @@ trait ProcessedTextBuilderTrait {
     // Hide the label.
     $options = ['label' => 'hidden'];
 
+    if ($trim_length) {
+      $options += [
+        'type' => 'smart_trim',
+        'settings' => [
+          'trim_length' => $trim_length,
+        ],
+      ];
+    }
+
     $element = $entity->get($field)->view($options);
+    return $wrap_prose ? $this->wrapProseText($element) : $element;
+  }
+
+  /**
+   * Build a (processed) text of the content and trim it.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity.
+   * @param string $field
+   *   Optional; The name of the field. Defaults to "field_body".
+   * @param bool $wrap_prose
+   *   Optional; If TRUE then wrap the text with the `prose` classes.
+   *   Defaults to FALSE.
+   * @param int $trim_length
+   *   The trim length. Defaults to 200 chars.
+   * @param bool $strip_tags
+   *   Determine if output should be stripped of most tags, and keep only a
+   *   smaller set of tags. Defaults to TRUE.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function buildProcessedTextTrimmed(FieldableEntityInterface $entity, string $field = 'field_body', bool $wrap_prose = FALSE, int $trim_length = 200, bool $strip_tags = TRUE) : array {
+    if (!$entity->hasField($field) || $entity->get($field)->isEmpty()) {
+      // Field is empty or doesn't exist.
+      return [];
+    }
+
+    // Hide the label.
+    $options = [
+      'label' => 'hidden',
+      'type' => 'smart_trim',
+      'settings' => [
+        'trim_length' => $trim_length,
+        'trim_suffix' => '…',
+      ],
+    ];
+
+    $element = $entity->get($field)->view($options);
+
+    if ($strip_tags && !empty($element[0]['#text'])) {
+      // Keep only a limited set of tags.
+      $element[0]['#text'] = strip_tags($element[0]['#text'], [
+        'strong',
+        'italic',
+        'ul',
+        'ol',
+      ]);
+    }
+
     return $wrap_prose ? $this->wrapProseText($element) : $element;
   }
 

--- a/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
+++ b/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
@@ -63,7 +63,6 @@ trait ProcessedTextBuilderTrait {
       return [];
     }
 
-    // Hide the label.
     $options = [
       'label' => 'hidden',
       'type' => 'smart_trim',

--- a/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
+++ b/web/modules/custom/server_general/src/ProcessedTextBuilderTrait.php
@@ -57,12 +57,13 @@ trait ProcessedTextBuilderTrait {
    * @return array
    *   Render array.
    */
-  protected function buildProcessedTextTrimmed(FieldableEntityInterface $entity, string $field = 'field_body', bool $wrap_prose = FALSE, int $trim_length = 200, bool $strip_tags = TRUE) : array {
+  protected function buildProcessedTextTrimmed(FieldableEntityInterface $entity, string $field = 'field_body', bool $wrap_prose = FALSE, int $trim_length = 200, bool $strip_tags = TRUE, int $line_clamp = 4) : array {
     if (!$entity->hasField($field) || $entity->get($field)->isEmpty()) {
       // Field is empty or doesn't exist.
       return [];
     }
 
+    // Hide the label.
     $options = [
       'label' => 'hidden',
       'type' => 'smart_trim',
@@ -82,6 +83,10 @@ trait ProcessedTextBuilderTrait {
         'ul',
         'ol',
       ]);
+    }
+
+    if ($line_clamp) {
+      $element = $this->wrapTextLineClamp($element, 4);
     }
 
     return $wrap_prose ? $this->wrapProseText($element) : $element;


### PR DESCRIPTION
- Enabled [Smart trim](https://www.drupal.org/project/smart_trim) module
- Added `buildProcessedTextTrimmed`, which also strips tags, so no images/ links would appear in the teaser.

![image](https://user-images.githubusercontent.com/125707/224508280-4adca152-e3e4-40fd-b9cf-0fda85433e92.png)
