### PR TITLE
Modernize PEVB plugins

### DIFF
--- a/web/modules/custom/server_general/src/CardTrait.php
+++ b/web/modules/custom/server_general/src/CardTrait.php
@@ -212,11 +212,9 @@ trait CardTrait {
       $items[] = $this->wrapTextResponsiveFontSize($subtitle, 'sm');
     }
 
-    $items = $this->wrapContainerVerticalSpacingTiny($items);
-
     return [
       '#theme' => 'server_theme_card__quick_link_item',
-      '#items' => $this->wrapContainerVerticalSpacing($items),
+      '#items' => $this->wrapContainerVerticalSpacingTiny($items),
       '#url' => $url,
     ];
 

--- a/web/modules/custom/server_general/src/ElementTrait.php
+++ b/web/modules/custom/server_general/src/ElementTrait.php
@@ -315,7 +315,32 @@ trait ElementTrait {
     $elements[] = $this->wrapContainerMaxWidth($element, '3xl');
 
     $elements[] = $this->buildCards($items);
-    return $this->wrapContainerVerticalSpacing($elements);
+    $elements = $this->wrapContainerVerticalSpacing($elements);
+    return $this->wrapContainerWide($elements);
+  }
+
+  /**
+   * Build a Title and text element.
+   *
+   * This is used by the Text paragraph type.
+   *
+   * @param string $title
+   *   The title.
+   * @param array $body
+   *   The body render array.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function buildElementTitleAndText(string $title, array $body): array {
+    $element = $this->wrapHtmlTag($title, 'h2');
+    $element = $this->wrapTextResponsiveFontSize($element, 'xl');
+    $elements[] = $element;
+
+    $elements[] = $body;
+
+    $elements = $this->wrapContainerVerticalSpacing($elements);
+    return $this->wrapContainerWide($elements);
   }
 
 }

--- a/web/modules/custom/server_general/src/ElementTrait.php
+++ b/web/modules/custom/server_general/src/ElementTrait.php
@@ -154,9 +154,12 @@ trait ElementTrait {
       return [];
     }
 
+    $header_items = [];
+    $header_items[] = $this->buildParagraphTitle($title);
+
     return [
       '#theme' => 'server_theme_carousel',
-      '#title' => $title,
+      '#header_items' => $header_items,
       '#items' => $items,
       '#button' => $button,
       '#is_featured' => $is_featured,
@@ -365,26 +368,21 @@ trait ElementTrait {
   }
 
   /**
-   * Build a Title and text element.
-   *
-   * This is used by the Text paragraph type.
+   * Build a Title and content element.
    *
    * @param string $title
    *   The title.
-   * @param array $body
-   *   The body render array.
+   * @param array $items
+   *   The content render array.
    *
    * @return array
    *   Render array.
    */
-  protected function buildElementTitleAndText(string $title, array $body): array {
-    $element = $this->wrapHtmlTag($title, 'h2');
-    $element = $this->wrapTextResponsiveFontSize($element, 'xl');
-    $elements[] = $element;
+  protected function buildElementParagraphTitleAndContent(string $title, array $items): array {
+    $elements[] = $this->buildParagraphTitle($title);
+    $elements[] = $items;
 
-    $elements[] = $body;
-
-    $elements = $this->wrapContainerVerticalSpacing($elements);
+    $elements = $this->wrapContainerVerticalSpacingBig($elements);
     return $this->wrapContainerWide($elements);
   }
 

--- a/web/modules/custom/server_general/src/ElementTrait.php
+++ b/web/modules/custom/server_general/src/ElementTrait.php
@@ -247,6 +247,51 @@ trait ElementTrait {
   }
 
   /**
+   * Build a Search term, facets and results element.
+   *
+   * This is used by the Search paragraph type.
+   *
+   * @param array $facets_items
+   *   The facets render array.
+   * @param bool $has_filters
+   *   Indicate if there are facet filters. That is, if a user has selected some
+   *   values in one or more of the facets.
+   * @param array $result_items
+   *   The render array of the results.
+   * @param string|null $search_term
+   *   The search term if exists. Defaults to NULL.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function buildElementSearchTermFacetsAndResults(array $facets_items, bool $has_filters, array $result_items, string $search_term = NULL): array {
+    $elements = [];
+
+    // Show the search term and facets if they exist.
+    $element = [];
+    if ($search_term) {
+      $element[] = [
+        '#theme' => 'server_theme_search_term',
+        '#search_term' => $search_term,
+      ];
+    }
+
+    $element[] = [
+      '#theme' => 'server_theme_facets__search',
+      '#items' => $facets_items,
+      '#has_filters' => $has_filters,
+    ];
+
+    $elements[] = $this->wrapContainerVerticalSpacing($element);
+
+    // Add the results.
+    $elements[] = $result_items;
+
+    $elements = $this->wrapContainerVerticalSpacingBig($elements);
+    return $this->wrapContainerWide($elements);
+  }
+
+  /**
    * Build a Quote.
    *
    * @param array $image

--- a/web/modules/custom/server_general/src/ElementTrait.php
+++ b/web/modules/custom/server_general/src/ElementTrait.php
@@ -279,11 +279,13 @@ trait ElementTrait {
       ];
     }
 
-    $element[] = [
-      '#theme' => 'server_theme_facets__search',
-      '#items' => $facets_items,
-      '#has_filters' => $has_filters,
-    ];
+    if ($facets_items) {
+      $element[] = [
+        '#theme' => 'server_theme_facets__search',
+        '#items' => $facets_items,
+        '#has_filters' => $has_filters,
+      ];
+    }
 
     $elements[] = $this->wrapContainerVerticalSpacing($element);
 

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeLandingPage.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeLandingPage.php
@@ -32,9 +32,12 @@ class NodeLandingPage extends NodeViewBuilderAbstract {
    */
   public function buildFull(array $build, NodeInterface $entity) {
     $elements = [];
+
     // Show the page title, unless it was set to be hidden.
-    $element = $this->buildConditionalPageTitle($entity);
-    $elements[] = $this->wrapContainerWide($element);
+    if (!$this->getBooleanFieldValue($entity, 'field_is_title_hidden')) {
+      $element = $this->buildPageTitle($entity->label());
+      $elements[] = $this->wrapContainerWide($element);
+    }
 
     /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $paragraphs */
     $paragraphs = $entity->get('field_paragraphs');

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphNewsTeasers.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphNewsTeasers.php
@@ -4,8 +4,7 @@ namespace Drupal\server_general\Plugin\EntityViewBuilder;
 
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\pluggable_entity_view_builder\EntityViewBuilderPluginAbstract;
-use Drupal\server_general\ElementWrapTrait;
-use Drupal\server_general\TitleAndLabelsTrait;
+use Drupal\server_general\ElementTrait;
 use Drupal\views\Views;
 
 /**
@@ -19,8 +18,7 @@ use Drupal\views\Views;
  */
 class ParagraphNewsTeasers extends EntityViewBuilderPluginAbstract {
 
-  use ElementWrapTrait;
-  use TitleAndLabelsTrait;
+  use ElementTrait;
 
   /**
    * Build full view mode.
@@ -36,26 +34,22 @@ class ParagraphNewsTeasers extends EntityViewBuilderPluginAbstract {
   public function buildFull(array $build, ParagraphInterface $entity): array {
     $view = Views::getView('news');
     if (empty($view)) {
-      return [];
+      return $build;
     }
 
     $view->preview('embed_1');
     $view->execute();
     if (empty($view->result)) {
       // No results. Do not render.
-      return [];
+      return $build;
     }
 
-    $element = $this->getTextFieldValue($entity, 'field_title');
-    $element = $this->buildParagraphTitle($element);
-    $elements[] = $element;
+    $element = $this->buildElementParagraphTitleAndContent(
+      $this->getTextFieldValue($entity, 'field_title'),
+      $view->buildRenderable('embed_1'),
+    );
 
-    $elements[] = $view->buildRenderable('embed_1');
-
-    $elements = $this->wrapContainerVerticalSpacingBig($elements);
-    $elements = $this->wrapContainerWide($elements);
-
-    $build[] = $elements;
+    $build[] = $element;
     return $build;
   }
 

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphQuickLinks.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphQuickLinks.php
@@ -55,7 +55,6 @@ class ParagraphQuickLinks extends EntityViewBuilderPluginAbstract {
       $items,
     );
 
-    $element = $this->wrapContainerWide($element);
     $build[] = $element;
 
     return $build;

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphSearch.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphSearch.php
@@ -7,8 +7,7 @@ namespace Drupal\server_general\Plugin\EntityViewBuilder;
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\pluggable_entity_view_builder\EntityViewBuilderPluginAbstract;
-use Drupal\server_general\ButtonTrait;
-use Drupal\server_general\ElementWrapTrait;
+use Drupal\server_general\ElementTrait;
 use Drupal\server_general\EmbedBlockTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,9 +23,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ParagraphSearch extends EntityViewBuilderPluginAbstract {
 
+  use ElementTrait;
   use EmbedBlockTrait;
-  use ButtonTrait;
-  use ElementWrapTrait;
 
   /**
    * The machine name of the facets to show.
@@ -81,17 +79,20 @@ class ParagraphSearch extends EntityViewBuilderPluginAbstract {
    *   Render array.
    */
   public function buildFull(array $build, ParagraphInterface $entity): array {
-    $elements = [];
+    // Facets.
+    $facets_items = [];
+    foreach ($this->facetNames as $facet_name) {
+      $facets_items[] = $this->embedBlock('facet_block:' . $facet_name);
+    }
 
-    // Search term and facets.
-    $elements[] = $this->buildSearchTermAndFacets();
+    $element = $this->buildElementSearchTermFacetsAndResults(
+      $facets_items,
+      $this->hasFilters('key'),
+      views_embed_view('search', 'embed_1'),
+      $this->request->query->get('key'),
+    );
 
-    // Add Main view.
-    $element = views_embed_view('search', 'embed_1');
-    $elements[] = $this->wrapContainerWide($element);
-
-    $element = $this->wrapContainerVerticalSpacingBig($elements);
-    $build[] = $this->wrapContainerBottomPadding($element);
+    $build[] = $element;
 
     return $build;
   }
@@ -111,39 +112,6 @@ class ParagraphSearch extends EntityViewBuilderPluginAbstract {
     return $this->request->query->filter($key) ||
       $this->request->query->filter('f') ||
       $this->request->query->filter('page');
-  }
-
-  /**
-   * Build the Search term and facets.
-   *
-   * @return array
-   *   Render array
-   */
-  protected function buildSearchTermAndFacets(): array {
-    $elements = [];
-    $search_term = $this->request->query->get('key');
-    if ($search_term) {
-      $element = [
-        '#theme' => 'server_theme_search_term',
-        '#search_term' => $search_term,
-      ];
-      $elements[] = $this->wrapContainerWide($element);
-    }
-
-    // Facets.
-    $items = [];
-    foreach ($this->facetNames as $facet_name) {
-      $items[] = $this->embedBlock('facet_block:' . $facet_name);
-    }
-
-    $element = [
-      '#theme' => 'server_theme_facets__search',
-      '#items' => $items,
-      '#has_filters' => $this->hasFilters('key'),
-    ];
-    $elements[] = $this->wrapContainerWide($element);
-
-    return $this->wrapContainerVerticalSpacing($elements);
   }
 
 }

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphText.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphText.php
@@ -4,7 +4,7 @@ namespace Drupal\server_general\Plugin\EntityViewBuilder;
 
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\pluggable_entity_view_builder\EntityViewBuilderPluginAbstract;
-use Drupal\server_general\ElementWrapTrait;
+use Drupal\server_general\ElementTrait;
 use Drupal\server_general\ProcessedTextBuilderTrait;
 
 /**
@@ -18,7 +18,7 @@ use Drupal\server_general\ProcessedTextBuilderTrait;
  */
 class ParagraphText extends EntityViewBuilderPluginAbstract {
 
-  use ElementWrapTrait;
+  use ElementTrait;
   use ProcessedTextBuilderTrait;
 
   /**
@@ -33,19 +33,12 @@ class ParagraphText extends EntityViewBuilderPluginAbstract {
    *   Render array.
    */
   public function buildFull(array $build, ParagraphInterface $entity): array {
-    $elements = [];
-    $element = $this->getTextFieldValue($entity, 'field_title');
+    $element = $this->buildElementTitleAndText(
+      $this->getTextFieldValue($entity, 'field_title'),
+      $this->buildProcessedText($entity, 'field_body'),
+    );
 
-    $element = $this->wrapHtmlTag($element, 'h2');
-    $element = $this->wrapTextResponsiveFontSize($element, 'xl');
-    $elements[] = $element;
-
-    $element = $this->buildProcessedText($entity, 'field_body');
-    $elements[] = $element;
-
-    $elements = $this->wrapContainerVerticalSpacing($elements);
-    $build[] = $this->wrapContainerWide($elements);
-
+    $build[] = $element;
     return $build;
   }
 

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphText.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/ParagraphText.php
@@ -33,7 +33,7 @@ class ParagraphText extends EntityViewBuilderPluginAbstract {
    *   Render array.
    */
   public function buildFull(array $build, ParagraphInterface $entity): array {
-    $element = $this->buildElementTitleAndText(
+    $element = $this->buildElementParagraphTitleAndContent(
       $this->getTextFieldValue($entity, 'field_title'),
       $this->buildProcessedText($entity, 'field_body'),
     );

--- a/web/modules/custom/server_general/src/TitleAndLabelsTrait.php
+++ b/web/modules/custom/server_general/src/TitleAndLabelsTrait.php
@@ -2,14 +2,10 @@
 
 namespace Drupal\server_general;
 
-use Drupal\pluggable_entity_view_builder\BuildFieldTrait;
-
 /**
  * Helper method for building Title and labels of a content.
  */
 trait TitleAndLabelsTrait {
-
-  use BuildFieldTrait;
 
   /**
    * Build the page title element.

--- a/web/modules/custom/server_general/src/TitleAndLabelsTrait.php
+++ b/web/modules/custom/server_general/src/TitleAndLabelsTrait.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\server_general;
 
-use Drupal\node\NodeInterface;
 use Drupal\pluggable_entity_view_builder\BuildFieldTrait;
 
 /**

--- a/web/modules/custom/server_general/src/TitleAndLabelsTrait.php
+++ b/web/modules/custom/server_general/src/TitleAndLabelsTrait.php
@@ -13,28 +13,6 @@ trait TitleAndLabelsTrait {
   use BuildFieldTrait;
 
   /**
-   * Build the page title and hide it if it's set to be hidden.
-   *
-   * The decision whether to hide it or not depends on the value of
-   * `field_is_title_hidden` field on the entity.
-   *
-   * @param \Drupal\node\NodeInterface $entity
-   *   The entity that's being built.
-   *
-   * @return array
-   *   The render array.
-   */
-  protected function buildConditionalPageTitle(NodeInterface $entity): array {
-    if ($entity->hasField('field_is_title_hidden') && $this->getBooleanFieldValue($entity, 'field_is_title_hidden')) {
-      // Title should be hidden.
-      return [];
-    }
-
-    return $this->buildPageTitle($entity->label());
-
-  }
-
-  /**
    * Build the page title element.
    *
    * @param string $title

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -334,7 +334,7 @@ class StyleGuideController extends ControllerBase {
       'News',
       $this->getRandomTitle(),
       Url::fromRoute('<front>'),
-      $this->buildProcessedText("Both refute. Of their its it funny children into good origin into self-interest, my she were bad of chosen stage italic, fame, is must didn't evaluate little may picture the didn't is not there of high accustomed. Him great those the sort alphabet she were workmen. Reflection bad the external gloomy not we it yet any them. What's late showed picture attached duck usual. To of actual writer fame. Prepared on was to stairs basically, the see would hadn't easier searching watched in and someone his where of the and written fly being a be his the to visuals was."),
+      $this->buildProcessedText("Both refute. Of their its it funny children into good origin into self-interest, my she were bad of chosen stage italic, fame, is must didn't evaluate little may picture the didn't is not there of high accustomed. Him great those the sort alphabet she were workmen. Reflection bad the external gloomy not we it yet any them. What's late showed picture attached duck usual. To of actual writer fame. Prepared on was to stairs basically, the see would hadn't easier searching watched in and someone his where of the and written fly being a be his the to visuals was.", FALSE),
       time()
     );
 
@@ -342,7 +342,7 @@ class StyleGuideController extends ControllerBase {
       'News',
       $this->getRandomTitle(),
       Url::fromRoute('<front>'),
-      $this->buildProcessedText("How does the system generate all this custom content?"),
+      $this->buildProcessedText("How does the system generate all this custom content?", FALSE),
       time()
     );
 
@@ -730,16 +730,21 @@ class StyleGuideController extends ControllerBase {
    *
    * @param string $text
    *   The text.
+   * @param bool $wrap_prose
+   *   Optional; If TRUE then wrap the text with the `prose` classes.
+   *   Defaults to TRUE.
    *
    * @return array
    *   A render array.
    */
-  protected function buildProcessedText(string $text) {
-    return [
+  protected function buildProcessedText(string $text, bool $wrap_prose = TRUE) {
+    $element = [
       '#type' => 'processed_text',
       '#text' => $text,
       '#format' => filter_default_format(),
     ];
+
+    return $wrap_prose ? $this->wrapProseText($element) : $element;
   }
 
   /**

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -123,7 +123,7 @@ class StyleGuideController extends ControllerBase {
     $build[] = $this->wrapElementWideContainer($element, 'Cards: With image (News cards)');
 
     $element = $this->getCardsWithImageHorizontalForNews();
-    $build[] = $this->wrapElementWideContainer($element, 'Cards: Horizontal with image (Featured content)');
+    $build[] = $this->wrapElementNoContainer($element, 'Cards: Horizontal with image (Featured content)');
 
     $element = $this->getRelatedContentCarousel(FALSE);
     $build[] = $this->wrapElementNoContainer($element, 'Cards: Carousel (Related content, not featured)');

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -156,7 +156,10 @@ class StyleGuideController extends ControllerBase {
     $build[] = $this->wrapElementNoContainer($element, 'Element: Quote');
 
     $element = $this->getQuickLinks();
-    $build[] = $this->wrapElementWideContainer($element, 'Element: Quick links');
+    $build[] = $this->wrapElementNoContainer($element, 'Element: Quick links');
+
+    $element = $this->getTitleAndText();
+    $build[] = $this->wrapElementNoContainer($element, 'Element: Title and text');
 
     $element = $this->getNodeNews();
     $build[] = $this->wrapElementNoContainer($element, 'Node view: News');
@@ -387,6 +390,19 @@ class StyleGuideController extends ControllerBase {
       $this->t('Quick Links'),
       $this->buildProcessedText('The Quick links description'),
       $items,
+    );
+  }
+
+  /**
+   * Get Title and text element.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function getTitleAndText(): array {
+    return $this->buildElementTitleAndText(
+      $this->getRandomTitle(),
+      $this->buildProcessedText('<p>I before parameters designer of the to separated of to part. Price question in or of a there sleep. Who a deference and drew sleep written talk said which had. sel in small been cheating sounded times should and problem. Question. Explorations derived been him aged seal for gods team- manage he according the welcoming are cities part up stands careful so own the have how up, keep</p>'),
     );
   }
 

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -113,9 +113,6 @@ class StyleGuideController extends ControllerBase {
 
     $build[] = $this->getTextDecorations();
 
-    $element = $this->getCards();
-    $build[] = $this->wrapElementWideContainer($element, 'Card: Simple (Search result)');
-
     $element = $this->getCardsCentered();
     $build[] = $this->wrapElementWideContainer($element, 'Card: Centered (Profile info)');
 
@@ -151,6 +148,9 @@ class StyleGuideController extends ControllerBase {
 
     $element = $this->getMediaVideo();
     $build[] = $this->wrapElementWideContainer($element, 'Element: Media Video');
+
+    $element = $this->getSearchTermFacetsAndResults();
+    $build[] = $this->wrapElementNoContainer($element, 'Element: Search term, facets and results');
 
     $element = $this->getQuote();
     $build[] = $this->wrapElementNoContainer($element, 'Element: Quote');
@@ -212,33 +212,6 @@ class StyleGuideController extends ControllerBase {
       'Social share trait',
       Url::fromUri('https://example.com'),
     );
-  }
-
-  /**
-   * Get Simple cards.
-   *
-   * @return array
-   *   Render array.
-   */
-  protected function getCards(): array {
-    $elements = [];
-    $elements[] = $this->buildCardSearchResult(
-      'News',
-      $this->getRandomTitle(),
-      Url::fromRoute('<front>'),
-      $this->buildProcessedText("Both refute. Of their its it funny children into good origin into self-interest, my she were bad of chosen stage italic, fame, is must didn't evaluate little may picture the didn't is not there of high accustomed. Him great those the sort alphabet she were workmen. Reflection bad the external gloomy not we it yet any them. What's late showed picture attached duck usual. To of actual writer fame. Prepared on was to stairs basically, the see would hadn't easier searching watched in and someone his where of the and written fly being a be his the to visuals was."),
-      time()
-    );
-
-    $elements[] = $this->buildCardSearchResult(
-      'News',
-      $this->getRandomTitle(),
-      Url::fromRoute('<front>'),
-      $this->buildProcessedText("How does the system generate all this custom content?"),
-      time()
-    );
-
-    return $this->wrapContainerVerticalSpacingBig($elements);
   }
 
   /**
@@ -338,6 +311,7 @@ class StyleGuideController extends ControllerBase {
    *   Render array.
    */
   protected function getMediaVideo(): array {
+
     return $this->buildElementVideo(
       'https://www.youtube.com/watch?v=dSZQNOvpszQ',
       650,
@@ -345,6 +319,40 @@ class StyleGuideController extends ControllerBase {
       FALSE,
       'This is the Credit of the video',
       'This is the Caption of the video',
+    );
+  }
+
+  /**
+   * Get Search term, facets and results.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function getSearchTermFacetsAndResults(): array {
+    $result_items = [];
+    $result_items[] = $this->buildCardSearchResult(
+      'News',
+      $this->getRandomTitle(),
+      Url::fromRoute('<front>'),
+      $this->buildProcessedText("Both refute. Of their its it funny children into good origin into self-interest, my she were bad of chosen stage italic, fame, is must didn't evaluate little may picture the didn't is not there of high accustomed. Him great those the sort alphabet she were workmen. Reflection bad the external gloomy not we it yet any them. What's late showed picture attached duck usual. To of actual writer fame. Prepared on was to stairs basically, the see would hadn't easier searching watched in and someone his where of the and written fly being a be his the to visuals was."),
+      time()
+    );
+
+    $result_items[] = $this->buildCardSearchResult(
+      'News',
+      $this->getRandomTitle(),
+      Url::fromRoute('<front>'),
+      $this->buildProcessedText("How does the system generate all this custom content?"),
+      time()
+    );
+
+    return $this->buildElementSearchTermFacetsAndResults(
+      // We can't easily theme the facets, so we skip that part on the style
+      // guide.
+      [],
+      FALSE,
+      $result_items,
+      'The search query',
     );
   }
 

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -408,7 +408,7 @@ class StyleGuideController extends ControllerBase {
    *   Render array.
    */
   protected function getTitleAndText(): array {
-    return $this->buildElementTitleAndText(
+    return $this->buildElementParagraphTitleAndContent(
       $this->getRandomTitle(),
       $this->buildProcessedText('<p>I before parameters designer of the to separated of to part. Price question in or of a there sleep. Who a deference and drew sleep written talk said which had. sel in small been cheating sounded times should and problem. Question. Explorations derived been him aged seal for gods team- manage he according the welcoming are cities part up stands careful so own the have how up, keep</p>'),
     );

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -149,6 +149,9 @@ class StyleGuideController extends ControllerBase {
     $element = $this->getMediaVideo();
     $build[] = $this->wrapElementWideContainer($element, 'Element: Media Video');
 
+    $element = $this->getParagraphTitleAndContent();
+    $build[] = $this->wrapElementNoContainer($element, 'Element: Paragraph title and content');
+
     $element = $this->getSearchTermFacetsAndResults();
     $build[] = $this->wrapElementNoContainer($element, 'Element: Search term, facets and results');
 
@@ -157,9 +160,6 @@ class StyleGuideController extends ControllerBase {
 
     $element = $this->getQuickLinks();
     $build[] = $this->wrapElementNoContainer($element, 'Element: Quick links');
-
-    $element = $this->getTitleAndText();
-    $build[] = $this->wrapElementNoContainer($element, 'Element: Title and text');
 
     $element = $this->getNodeNews();
     $build[] = $this->wrapElementNoContainer($element, 'Node view: News');
@@ -402,12 +402,12 @@ class StyleGuideController extends ControllerBase {
   }
 
   /**
-   * Get Title and text element.
+   * Get Paragraph title and content element.
    *
    * @return array
    *   Render array.
    */
-  protected function getTitleAndText(): array {
+  protected function getParagraphTitleAndContent(): array {
     return $this->buildElementParagraphTitleAndContent(
       $this->getRandomTitle(),
       $this->buildProcessedText('<p>I before parameters designer of the to separated of to part. Price question in or of a there sleep. Who a deference and drew sleep written talk said which had. sel in small been cheating sounded times should and problem. Question. Explorations derived been him aged seal for gods team- manage he according the welcoming are cities part up stands careful so own the have how up, keep</p>'),

--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -298,7 +298,9 @@ function server_theme_theme() {
 
   $info['server_theme_carousel'] = [
     'variables' => [
-      'title' => NULL,
+      // Render array of the header items. For example, the paragraph title.
+      'header_items' => NULL,
+      // The items of the carousel.
       'items' => [],
       // Indicate if cards are featured, thus we show only a single card at a
       // time.

--- a/web/themes/custom/server_theme/templates/server-theme-carousel.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-carousel.html.twig
@@ -1,8 +1,6 @@
 <div class="bg-gray-100 py-4 md:py-5">
   <div class="container-wide flex flex-col gap-6 md:gap-8 lg:gap-10">
-    {% if title %}
-      <h2>{{ title }}</h2>
-    {% endif %}
+    {{ header_items }}
 
     {% embed '@server_theme/server-theme-carousel-base.html.twig' %}
       {% set dots = 'true' %}


### PR DESCRIPTION
- All PEVBs are now calling `buildElement...`, so they are all having consistent code
- Added new elements to Style guide
- `\Drupal\server_style_guide\Controller\StyleGuideController::buildProcessedText` now wraps text with `prose`, like we do on PEVB.


| Element | Style guide | PEVB |
| -- | -- | -- |
| Search | ![image](https://user-images.githubusercontent.com/125707/226678848-82957d53-7ef5-4799-9452-95bb8c80fef7.png) | ![image](https://user-images.githubusercontent.com/125707/226678977-4001063d-3ffa-4cd2-beab-9267ec528aa7.png) |
| Carousel | ![image](https://user-images.githubusercontent.com/125707/226679365-395505cf-410e-453c-b743-1d187df643ab.png) | ![image](https://user-images.githubusercontent.com/125707/226679421-14a8cc6f-7272-44eb-8158-6ab3836a37ca.png) | 
| Paragraph title and content (Used by `Text` paragraph type) | ![image](https://user-images.githubusercontent.com/125707/226680953-fea41958-5885-4af5-bfcb-d8262987a53e.png) | ![image](https://user-images.githubusercontent.com/125707/226681002-cff189dd-13ff-4af1-b68c-66c1391a3c67.png) |




