### PR TITLE
Do not deploy txt files to Pantheon at all

### DIFF
--- a/pantheon_template/gitignore-template
+++ b/pantheon_template/gitignore-template
@@ -60,3 +60,4 @@ Thumbs.db
 # Things in the core directory that Drupal 8 commits in the repository.
 !core/**/*.gz
 
+*.txt

--- a/pantheon_template/gitignore-template
+++ b/pantheon_template/gitignore-template
@@ -61,3 +61,4 @@ Thumbs.db
 !core/**/*.gz
 
 *.txt
+*.md


### PR DESCRIPTION
We'd leak lots of information in those files.
Version numbers, patches, and so on.