### PR TITLE
Robo traits - Make the structure coherent

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -9,11 +9,11 @@ use RoboComponents\ReleaseNotesTrait;
 use RoboComponents\ThemeTrait;
 use RoboComponents\DeploymentTrait;
 use RoboComponents\PhpcsTrait;
+use RoboComponents\TranslationManagement\ExportFromConfig;
+use RoboComponents\TranslationManagement\ImportToConfig;
+use RoboComponents\TranslationManagement\ImportToUi;
 use RoboComponents\ElasticSearchTrait;
 use Symfony\Component\HttpFoundation\Request;
-use TranslationManagement\ExportFromConfig;
-use TranslationManagement\ImportToConfig;
-use TranslationManagement\ImportToUi;
 
 $GLOBALS['drupal_autoloader'] = require_once 'web/autoload.php';
 

--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,7 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "RoboComponents\\": "./robo-components/",
-            "TranslationManagement\\": "./translation_management/"
+            "RoboComponents\\": "./robo-components/"
         }
     },
     "config": {

--- a/robo-components/TranslationManagement/ExportFromConfig.php
+++ b/robo-components/TranslationManagement/ExportFromConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TranslationManagement;
+namespace RoboComponents\TranslationManagement;
 
 use Drupal\Component\Utility\Tags;
 use Gettext\Generator\PoGenerator;

--- a/robo-components/TranslationManagement/ExportFromConfig.php
+++ b/robo-components/TranslationManagement/ExportFromConfig.php
@@ -2,7 +2,6 @@
 
 namespace RoboComponents\TranslationManagement;
 
-use Drupal\Component\Utility\Tags;
 use Gettext\Generator\PoGenerator;
 use Gettext\Translation;
 use Gettext\Translations;
@@ -130,6 +129,8 @@ trait ExportFromConfig {
    *   A prefix to load configs. Example 'field.field.node.'.
    * @param array $keys
    *   An array of keys to extract the value. Example: ['label', 'menu.title'].
+   * @param string $langcode
+   *   The langcode of the translations to fetch.
    *
    * @return array
    *   A list of original value and the ID.

--- a/robo-components/TranslationManagement/ImportToConfig.php
+++ b/robo-components/TranslationManagement/ImportToConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TranslationManagement;
+namespace RoboComponents\TranslationManagement;
 
 use Gettext\Loader\PoLoader;
 use Gettext\Translations;

--- a/robo-components/TranslationManagement/ImportToUi.php
+++ b/robo-components/TranslationManagement/ImportToUi.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TranslationManagement;
+namespace RoboComponents\TranslationManagement;
 
 use Robo\ResultData;
 use RoboComponents\DeploymentTrait;


### PR DESCRIPTION
We had some robo traits under `translation_management`, and some others under `robo-components`. Now it's coherent