### PR TITLE
Upgrade Ubuntu to Jammy inside Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 version: "~> 1.0"
 language: php
-dist: focal
+dist: jammy
 php:
 - 8.1
 services:


### PR DESCRIPTION
"On the Ubuntu 22.04 based environment, to speed up boot time and improve performance we’ve disabled all services by default. Add any services that you want to start to your .travis.yml:"

This is appealing for us!