### PR TITLE
Add required config data for PEVB settings

### DIFF
--- a/config/sync/pluggable_entity_view_builder.settings.yml
+++ b/config/sync/pluggable_entity_view_builder.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: pjtgLypHijxpYmSoWGgjo3ou6Y6V3Va3ZyyJY7Ha3i4
 enabled_entity_types:
   media: media
   node: node


### PR DESCRIPTION
#374 

```
$ ddev restart
Restarting project drupal-starter... 
Container ddev-drupal-starter-dba  Removed 
Container ddev-drupal-starter-db  Removed 
Container ddev-drupal-starter-web  Removed 
Container ddev-drupal-starter-redis  Removed 
Container ddev-drupal-starter-elasticsearch  Removed 
Network ddev-drupal-starter_default  Removed 
Using custom PHP configuration: [/home/baysaa/www/drupal-starter/.ddev/php/memory-limit.php.ini] 
Custom configuration is updated on restart.
If you don't see your custom configuration taking effect, run 'ddev restart'. 
Network ddev-drupal-starter_default  Created 
Container ddev-drupal-starter-elasticsearch  Started 
Container ddev-drupal-starter-dba  Started 
Container ddev-drupal-starter-db  Started 
Container ddev-drupal-starter-redis  Started 
Container ddev-drupal-starter-web  Started 
Container ddev-router  Running 
settings.ddev.php already exists and is managed by the user. 
User-managed /home/baysaa/www/drupal-starter/web/sites/default/.gitignore will not be managed/overwritten by ddev 

 You are about to:
 * DROP all tables in your 'db' database.

 [notice] Starting Drupal installation. This takes a while.
 [notice] Performed install task: install_select_language
 [notice] Performed install task: install_select_profile
 [notice] Performed install task: install_load_profile
 [notice] Performed install task: install_verify_requirements
 [notice] Performed install task: install_verify_database_ready
 [notice] Performed install task: install_base_system
 [notice] Performed install task: install_bootstrap_full

^ this is usually where the error appears

 [notice] Performed install task: install_config_import_batch
 [notice] Performed install task: install_config_revert_install_changes
 [notice] Performed install task: install_configure_form
 [notice] Performed install task: install_finished
 [success] Installation complete.  User name: admin  User password: yw6bk2R62X
 [ParallelExec] curl -u : -X PUT http://elasticsearch:9200/elasticsearch_index_db_server_qa
```

Steps took to fix this:

- [Patched PEVB](https://www.drupal.org/project/pluggable_entity_view_builder/issues/3363609) to provide installation config (Needs review)
- Uninstall PEVB on drupal-starter
- Export config (deletes pluggable_entity_view_builder.settings.yml)
- Re-enable PEVB
- Export config (exported new PEVB settings with `_core.default_config_hash`