### PR TITLE
Travis wait - gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ web/sites/all/drush
 # Patching leftover.
 *.orig
 *.rej
+
+travis_wait*log


### PR DESCRIPTION
At one of the client projects, we had this recently:
```
The command "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/prepare_deploy.sh) || travis_terminate 1;" exited with 0.

8.01s$ travis_retry ddev robo deploy:pantheon --no-interaction master

 [Exec] Running git status -s

 [Exec] Done in 0.188s

>  ?? travis_wait_2620.log

 [error]  The Pantheon directory is dirty. Please commit any pending changes. 

Failed to run robo deploy:pantheon --no-interaction master: exit status 1
```