### PR TITLE
Install and enable admin_toolbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "bower-asset/fontawesome": "^6.4",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
+        "drupal/admin_toolbar": "^3.4",
         "drupal/advagg": "^6.0@alpha",
         "drupal/classy": "^1.0",
         "drupal/config_filter": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c619d4b7b4dce74e883ffcd1e5a3be93",
+    "content-hash": "76a715497d8f7dc20c8ec00aae9bde9f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1480,6 +1480,87 @@
                 }
             ],
             "time": "2022-12-14T08:49:07+00:00"
+        },
+        {
+            "name": "drupal/admin_toolbar",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/admin_toolbar.git",
+                "reference": "3.4.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/admin_toolbar-3.4.1.zip",
+                "reference": "3.4.1",
+                "shasum": "bcb15ab40016becdb3ac8f21d7d1a721f48f3577"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/admin_toolbar_tools": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.4.1",
+                    "datestamp": "1684944156",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wilfrid Roze (eme)",
+                    "homepage": "https://www.drupal.org/u/eme",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Romain Jarraud (romainj)",
+                    "homepage": "https://www.drupal.org/u/romainj",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Adrian Cid Almaguer (adriancid)",
+                    "homepage": "https://www.drupal.org/u/adriancid",
+                    "email": "adriancid@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Mohamed Anis Taktak (matio89)",
+                    "homepage": "https://www.drupal.org/u/matio89",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "matio89",
+                    "homepage": "https://www.drupal.org/user/2320090"
+                },
+                {
+                    "name": "Musa.thomas",
+                    "homepage": "https://www.drupal.org/user/1213824"
+                },
+                {
+                    "name": "romainj",
+                    "homepage": "https://www.drupal.org/user/370706"
+                }
+            ],
+            "description": "Provides a drop-down menu interface to the core Drupal Toolbar.",
+            "homepage": "http://drupal.org/project/admin_toolbar",
+            "keywords": [
+                "Drupal",
+                "Toolbar"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/admin_toolbar",
+                "issues": "https://www.drupal.org/project/issues/admin_toolbar"
+            }
         },
         {
             "name": "drupal/advagg",

--- a/config/sync/admin_toolbar.settings.yml
+++ b/config/sync/admin_toolbar.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: jvTSppzcgH5wnzBhX5xnAExcp2I1CzkQ_aky65XNfYI
+menu_depth: 4

--- a/config/sync/admin_toolbar_search.settings.yml
+++ b/config/sync/admin_toolbar_search.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: AAmWcgwzGYbXfR6wfEfMyoi3r5QZwlpxvq5dHbupnJo
+display_menu_item: 0

--- a/config/sync/admin_toolbar_tools.settings.yml
+++ b/config/sync/admin_toolbar_tools.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: WgdZsrd_5w9jlmcHV4R9dD2tG9OZEkYo4I_O8h7Gq8Q
+max_bundle_number: 20
+hoverintent_functionality: true
+show_local_tasks: false

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,6 +1,10 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
+  admin_toolbar: 0
+  admin_toolbar_links_access_filter: 0
+  admin_toolbar_search: 0
+  admin_toolbar_tools: 0
   automated_cron: 0
   big_pipe: 0
   block: 0


### PR DESCRIPTION
This commit adds `drupal/admin_toolbar` to `composer.json` and enables the module and it's submodules:

*Admin Toolbar*:
Provides an improved drop-down menu interface to the site Toolbar.

*Admin Toolbar Extra Tools*:
Adds menu links like Flush cache, Run cron, Run updates, and Logout under Drupal icon.

*Admin Toolbar Links Access Filter*:
Provides a workaround for the common problem that users with 'Use the administration pages and help' permission see menu links they don't have access permission for. Once the issue https://www.drupal.org/node/296693 be solved, this module will be deprecated.

*Admin Toolbar Search*:
Provides search of Admin Toolbar items.