### PR TITLE
Fix wrong background-repeat on Status messages.

### DIFF
--- a/robo-components/ElasticSearchTrait.php
+++ b/robo-components/ElasticSearchTrait.php
@@ -77,7 +77,7 @@ trait ElasticSearchTrait {
    *   The password of the ES admin user.
    * @param string|null $environment
    *   The environment ID. To test changes in the index config selectively.
-   * @param bool $needs_users_override
+   * @param bool|null $needs_users_override
    *   Set to TRUE to create a secrets.json file.
    *
    * @throws \Exception

--- a/web/themes/custom/server_theme/templates/status-messages.html.twig
+++ b/web/themes/custom/server_theme/templates/status-messages.html.twig
@@ -30,7 +30,7 @@
   {% elseif type == 'status' %}
     {% set message_class = 'bg-green-400' %}
   {% endif %}
-  <div role="contentinfo" aria-label="{{ status_headings[type] }}"{{ attributes|without('role', 'aria-label') }} class="{{ message_class }} messages--{{ type }} text-white py-2 px-4 rounded rounded-large text-left mt-4 [&_a]:underline">
+  <div role="contentinfo" aria-label="{{ status_headings[type] }}"{{ attributes|without('role', 'aria-label') }} class="{{ message_class }} bg-none shadow-none border-0 messages--{{ type }} text-white py-2 px-4 rounded rounded-large text-left mt-4 [&_a]:underline">
     {% if type == 'error' %}
       <div role="alert">
     {% endif %}


### PR DESCRIPTION
#553 

### Update:
- Fixed wrong background-repeat on Status messages.

Before|After
-|-
![before](https://github.com/Gizra/drupal-starter/assets/4610167/30b554a9-5a7b-402e-a49b-678ca176bdcb)|![after](https://github.com/Gizra/drupal-starter/assets/4610167/dc244e96-86cb-4335-8dbb-5454caec8057)

**TB:0.5/1h**