### PR TITLE
Fix deprecated stylesheets-remove key.

### DIFF
--- a/web/themes/custom/server_theme/server_theme.info.yml
+++ b/web/themes/custom/server_theme/server_theme.info.yml
@@ -19,11 +19,23 @@ regions:
   content: Content
   footer: Footer
 
-# Remove CSS files
-stylesheets-remove:
-  - core/themes/classy/css/components/details.css
-  - core/themes/classy/css/components/file.css
-  - core/themes/classy/css/components/form.css
-  - core/themes/classy/css/components/links.css
-  - core/themes/classy/css/components/messages.css
-  - core/themes/stable/css/system/components/ajax-progress.module.css
+# Remove CSS files by overriding libraries.
+libraries-override:
+  classy/base:
+    css:
+      component:
+        css/components/details.css: false
+        css/components/form.css: false
+        css/components/links.css: false
+  classy/file:
+    css:
+      component:
+        css/components/file.css: false
+  classy/messages:
+    css:
+      component:
+        css/components/messages.css: false
+  system/base:
+    css:
+      components:
+        /themes/contrib/stable/css/system/components/ajax-progress.module.css: false


### PR DESCRIPTION
After upgrading to Drupal 10 we need to replace deprecated key "stylesheets-remove" with "override-libraries" key (like in [example here](https://www.drupal.org/project/bootstrap4/issues/3301308)). 

Stable theme already overrides some CSS in the same way, so in order to override already overridden libraries, we need to use full path and also override system/base.