### PR TITLE
Fix strstr error in config path

### DIFF
--- a/config/sync/locale.settings.yml
+++ b/config/sync/locale.settings.yml
@@ -1,2 +1,7 @@
 translation:
+  default_filename: '%project-%version.%language.po'
+  overwrite_customized: false
+  overwrite_not_customized: false
   path: sites/default/files/translations
+  update_interval_days: 0
+  use_source: local

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralConfigTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralConfigTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Symfony\Component\HttpFoundation\Response;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Config based tests.
+ */
+class ServerGeneralConfigTest extends ExistingSiteBase {
+
+  /**
+   * Test no warning is displayed when visiting the config page.
+   */
+  public function testConfigPage() {
+    $user = $this->createUser();
+    $user->addRole('administrator');
+    $user->save();
+
+    $this->drupalLogin($user);
+
+    $this->drupalGet('/admin/config');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $this->assertSession()->elementNotExists('css', '.messages--warning');
+  }
+
+}


### PR DESCRIPTION
#552 

I traced this error to this issue. https://www.drupal.org/project/drupal/issues/3318180 It seems the config missing added by this PR fixes the problem.

@amitaibu I thought in adding a test for this but maybe it will be problematic in a future. checking if there is some message-error in the config page. What do you think?

1/3

