### PR TITLE
Retry `install_ddev.sh` step

### DIFF
--- a/.travis.template.yml
+++ b/.travis.template.yml
@@ -42,14 +42,14 @@ jobs:
     name: 'Backend tests: Functional tests'
     if: (branch != "{{ GITHUB_DEPLOY_BRANCH }}" AND tag IS blank)
     script:
-    - "$TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh || travis_terminate 1;"
+    - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
   - stage: Deploy
     name: 'Backend tests: Functional tests and deploy to Pantheon'
     if: branch = "{{ GITHUB_DEPLOY_BRANCH }}" AND type = push
     script:
-    - "$TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh || travis_terminate 1;"
+    - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/prepare_deploy.sh) || travis_terminate 1;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,14 @@ jobs:
     name: 'Backend tests: Functional tests'
     if: (branch != "main" AND tag IS blank)
     script:
-    - "$TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh || travis_terminate 1;"
+    - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
   - stage: Deploy
     name: 'Backend tests: Functional tests and deploy to Pantheon'
     if: branch = "main" AND type = push
     script:
-    - "$TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh || travis_terminate 1;"
+    - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/prepare_deploy.sh) || travis_terminate 1;"

--- a/ci-scripts/install_ddev.sh
+++ b/ci-scripts/install_ddev.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 echo "Logging into Docker Hub if the password is set"
 if [ -z "${DOCKER_PASSWORD}" ]; then
@@ -14,7 +13,13 @@ curl -s -L https://raw.githubusercontent.com/drud/ddev/master/scripts/install_dd
 echo "Configuring ddev."
 mkdir ~/.ddev
 cp "ci-scripts/global_config.yaml" ~/.ddev/
-docker network create ddev_default || ddev logs
 
-ddev composer install || ddev logs
+if ! docker network create ddev_default; then
+ddev logs
+  exit 1
+fi
 
+if ! ddev composer install; then
+  ddev logs
+  exit 1
+fi


### PR DESCRIPTION
When we install DDEV, a number of things happen: 
 - Downloading DDEV itself
 - Downloading Docker images from multiple sources sometimes
 - Downloading APT packages

and so one. One network failure should not halt the process.