### PR TITLE
Add svgo config to disable stripping viewBox attribute

### DIFF
--- a/web/themes/custom/server_theme/svgo.config.js
+++ b/web/themes/custom/server_theme/svgo.config.js
@@ -1,0 +1,16 @@
+// svgo.config.js
+module.exports = {
+  multipass: true, // boolean. false by default
+  plugins: [
+    {
+      name: 'preset-default',
+      params: {
+        overrides: {
+          // viewBox is required to resize SVGs with CSS.
+          // @see https://github.com/svg/svgo/issues/1128
+          removeViewBox: false,
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Looks like svgo is responsible for stripping out viewbox attribute which makes scaling worse. Adding this config file disables it.

@see https://github.com/svg/svgo#troubleshooting
and https://github.com/svg/svgo/issues/1128