### PR TITLE
Center header text for info card elements

### DIFF
--- a/web/modules/custom/server_general/src/InnerElementTrait.php
+++ b/web/modules/custom/server_general/src/InnerElementTrait.php
@@ -216,6 +216,7 @@ trait InnerElementTrait {
 
     $element = $this->wrapTextFontWeight($header, 'bold');
     $element = $this->wrapTextResponsiveFontSize($element, '3xl');
+    $element = $this->wrapTextCenter($element);
     $elements[] = $element;
 
     $bottom_elements = [];


### PR DESCRIPTION
This fixes #566 

Is this the desired approach? I'm just following the same that is done for the other two pieces of text in the element.

The way I see it, having 3 div wrappers for one sentence is a bit of an overkill:

```
<div class="text-center">
  <div class="text-xl md:text-2xl lg:text-3xl">
    <div class="font-bold">
      Info card with multiple lines in header looks off
    </div>
  </div>
</div>
```

I was tempted to remove the `$this->wrapTextCenter($element)` line from each part and just add `text-center` class to the wrapper, but `themes/custom/server_theme/templates/server-theme-inner-element-layout-base.html.twig` is used by several other elements...