### PR TITLE
Verify facet configuration

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
@@ -120,10 +120,11 @@ class ServerGeneralSearchTest extends ServerGeneralSearchTestBase {
       $config_value = $facet->getThirdPartySetting('facets', 'only_visible_when_facet_source_is_visible', NULL);
 
       // Check if 'only_visible_when_facet_source_is_visible' is set to false.
-      if ($config_value !== FALSE) {
+      if ($config_value === TRUE) {
         $this->fail("The facet {$facet->id()} has 'only_visible_when_facet_source_is_visible' set to true.");
       }
     }
+    $this->expectNotToPerformAssertions();
   }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
@@ -117,12 +117,12 @@ class ServerGeneralSearchTest extends ServerGeneralSearchTestBase {
 
     /** @var \Drupal\facets\FacetInterface $facet */
     foreach ($facets as $facet) {
-      $config_value = $facet->getThirdPartySetting('facets', 'only_visible_when_facet_source_is_visible', NULL);
+      $config_value = $facet->get('only_visible_when_facet_source_is_visible');
 
-      // Check if 'only_visible_when_facet_source_is_visible' is set to false.
-      if ($config_value === TRUE) {
-        $this->fail("The facet {$facet->id()} has 'only_visible_when_facet_source_is_visible' set to true.");
+      if (!$config_value) {
+        continue;
       }
+      $this->fail("The facet {$facet->id()} has 'only_visible_when_facet_source_is_visible' set to true. It is not compatible with Paragraphs-based embedding and rendering.");
     }
     $this->expectNotToPerformAssertions();
   }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\Tests\server_general\ExistingSite;
 
-use Drupal\facets\FacetInterface;
-
 /**
  * A test case to test search integration.
  */
@@ -117,7 +115,7 @@ class ServerGeneralSearchTest extends ServerGeneralSearchTestBase {
       return;
     }
 
-    /** @var FacetInterface $facet */
+    /** @var \Drupal\facets\FacetInterface $facet */
     foreach ($facets as $facet) {
       $config_value = $facet->getThirdPartySetting('facets', 'only_visible_when_facet_source_is_visible', NULL);
 

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSearchTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\server_general\ExistingSite;
 
+use Drupal\facets\FacetInterface;
+
 /**
  * A test case to test search integration.
  */
@@ -101,6 +103,29 @@ class ServerGeneralSearchTest extends ServerGeneralSearchTestBase {
       // The second result should be the one with the word in the body.
       $assert->elementTextEquals('xpath', "(//div[contains(@class, 'views-row')])[2]//a", 'something else in the title');
     });
+  }
+
+  /**
+   * Tests the sanity of facet configurations.
+   */
+  public function testFacetConfigSanity() {
+    $facets = \Drupal::entityTypeManager()
+      ->getStorage('facets_facet')
+      ->loadMultiple();
+
+    if (empty($facets)) {
+      return;
+    }
+
+    /** @var FacetInterface $facet */
+    foreach ($facets as $facet) {
+      $config_value = $facet->getThirdPartySetting('facets', 'only_visible_when_facet_source_is_visible', NULL);
+
+      // Check if 'only_visible_when_facet_source_is_visible' is set to false.
+      if ($config_value !== FALSE) {
+        $this->fail("The facet {$facet->id()} has 'only_visible_when_facet_source_is_visible' set to true.");
+      }
+    }
   }
 
 }


### PR DESCRIPTION
With the Search paragraph type, we need to make sure facet is configured properly, otherwise someone might debug it for a while why facets are missing.