### PR TITLE
Add -p flag to mkdir command in config.local.yaml.example

### DIFF
--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -7,7 +7,7 @@ web_environment:
 hooks:
   post-start:
     # Private files directory.
-    - exec: mkdir /var/www/private
+    - exec: mkdir -p /var/www/private
 
     # Create a private key for Two-factor Authentication if not yet added.
     - exec-host: ddev set-tfa-key


### PR DESCRIPTION
This prevents mkdir error when the private files folder already exists

`mkdir: cannot create directory ‘/var/www/private’: File exists`