### PR TITLE
Separate Test & Deploy steps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,41 +41,37 @@ jobs:
     - "$TRAVIS_BUILD_DIR/ci-scripts/test_shell.sh || travis_terminate 1;"
   - stage: Test
     name: 'Backend tests: Functional tests'
-    if: (branch != "main" AND tag IS blank)
     script:
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
   - stage: Deploy
-    name: 'Backend tests: Functional tests and deploy to Pantheon QA'
+    name: 'Deploy to Pantheon QA'
     if: branch = "main" AND type = push AND tag IS blank
     script:
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
-    - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/prepare_deploy.sh) || travis_terminate 1;"
     - "(travis_retry ddev robo deploy:pantheon qa --no-interaction) || travis_terminate 1;"
     - ddev composer install || travis_terminate 1;
     - ddev robo deploy:notify || travis_terminate 1;
   - stage: Deploy
-    name: 'Backend tests: Functional tests and deploy to Pantheon TEST'
+    name: 'Backend tests: Deploy to Pantheon TEST'
     if: tag IS present AND type = "push" AND tag !~ /live$/
     script:
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
-    - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/prepare_deploy.sh) || travis_terminate 1;"
     - "(travis_retry ddev robo deploy:tag-pantheon --no-interaction $TRAVIS_TAG master) || travis_terminate 1;"
     - "ddev composer install || travis_terminate 1;"
     - "(travis_retry ddev robo deploy:pantheon-sync) || travis_terminate 1;"
   - stage: Deploy
-    name: 'Backend tests: Functional tests and deploy to Pantheon LIVE'
+    name: 'Backend tests: Deploy to Pantheon LIVE'
     if: tag IS present AND type = "push" AND tag =~ /live$/
     script:
     - "$TRAVIS_BUILD_DIR/ci-scripts/check_live_deploy.sh || travis_terminate 1;"
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/install_ddev.sh) || travis_terminate 1;"
     - "$TRAVIS_BUILD_DIR/ci-scripts/install_drupal.sh || travis_terminate 1;"
-    - "$TRAVIS_BUILD_DIR/ci-scripts/test_phpunit.sh || travis_terminate 1;"
     - "(travis_retry $TRAVIS_BUILD_DIR/ci-scripts/prepare_deploy.sh) || travis_terminate 1;"
     - "(travis_retry ddev robo deploy:pantheon-sync live) || travis_terminate 1;"
 after_failure:


### PR DESCRIPTION
### Context:
Sometimes during deployment, the build passes all tests but the deployment fails due to some issue in git, redis, etc. In such cases, to trigger the deployment, we need to re-run the whole test+deploy. 

This will allow us to trigger deployment without triggering tests.