### PR TITLE
CKEeditor HTML source breaks page layout when there are very long strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "drupal/core": {
+                "d.o. 3400204": "https://www.drupal.org/files/issues/2023-11-23/claro-ck5-long-url.patch"
+            },
             "drupal/elasticsearch_connector": {
                 "Preserve ES index settings": "https://www.drupal.org/files/issues/2020-01-28/3109361-elasticsearch_connector-preserve-index-settings-1.patch",
                 "d.o. #3106003 - Content access fixes": "https://www.drupal.org/files/issues/2021-01-12/missing-special-fields-3106003-8.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1a62f93503d0aabbb5e34a178f58296",
+    "content-hash": "2f3420f5ec00cf0783213f81bb610a95",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
When using Claro theme, CKEditor HTML source view breaks page layout when there are very long strings in HTML source (e.g. href value).