### PR TITLE
Fix translator role issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,6 +134,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "drupal/core": {
+                "d.o. #3197416": "https://www.drupal.org/files/issues/2023-11-18/3197416-medialibrary-fieldwidgetopenercheckaccess-denies-access-on-a-translated-entity-revision.patch"
+            },
             "drupal/elasticsearch_connector": {
                 "Preserve ES index settings": "https://www.drupal.org/files/issues/2020-01-28/3109361-elasticsearch_connector-preserve-index-settings-1.patch",
                 "d.o. #3106003 - Content access fixes": "https://www.drupal.org/files/issues/2021-01-12/missing-special-fields-3106003-8.patch",

--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,9 @@
             },
             "npm-asset/anchor-js": {
                 "remove font-face": "patches/remove-anchorjs-fontface.patch"
+            },
+            "drupal/paragraphs": {
+                "d.o. 2925533": "https://www.drupal.org/files/issues/paragraphs-translation_paragraph_issue-2925533-2.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1a62f93503d0aabbb5e34a178f58296",
+    "content-hash": "6e2106bef5762bfb045ccbc7edf310f4",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e2106bef5762bfb045ccbc7edf310f4",
+    "content-hash": "8b4c3a84513724cbb47ab09bd3119f33",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
When we have a translator role that doesn't have edit permissions we encounter two translation issues that this PR fixes:

1. Referenced Paragraph cannot be accessed for translation
2. Media library introduced edit permission check that pure translator role shouldn't have (such translator role is able to only add/update translations and not to edit source node and this is supported by Drupal core). This permission check for such translator role, results in AJAX error which the applied fix prevents and allows a media entity to be changed/translated in translated node. 