### PR TITLE
Move patches from composer.json to an external patch file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,33 +133,7 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
-        "patches": {
-            "drupal/core": {
-                "d.o. 3400204": "https://www.drupal.org/files/issues/2023-11-23/claro-ck5-long-url.patch"
-            },
-            "drupal/elasticsearch_connector": {
-                "Preserve ES index settings": "https://www.drupal.org/files/issues/2020-01-28/3109361-elasticsearch_connector-preserve-index-settings-1.patch",
-                "d.o. #3106003 - Content access fixes": "https://www.drupal.org/files/issues/2021-01-12/missing-special-fields-3106003-8.patch",
-                "d.o. #3194318 - More robust language filtering": "https://www.drupal.org/files/issues/2021-01-25/3194318-hypen-lang-5.patch",
-                "d.o. #3014805 - Views filtering with facets": "https://www.drupal.org/files/issues/2019-12-20/elasticsearch_connector-facet_OR_global_aggregation_does_not_take_views_filter_into_account-3014805-15.patch",
-                "d.o. #2952301": "https://www.drupal.org/files/issues/2021-03-11/elasticsearch_connector_luceneFlattenKeys--2952301-14.patch"
-            },
-            "drupal/entity_reference_revisions": {
-              "d.o. 2799479": "https://www.drupal.org/files/issues/2022-06-01/entity_reference_revisions-relationship_host_id-2799479-176.patch"
-            },
-            "drupal/google_analytics": {
-              "d.o #3373921": "https://www.drupal.org/files/issues/2023-08-07/google-analytics-issues-3373921-cannot-install-from-existing-config-11.patch"
-            },
-            "nodespark/des-connector": {
-              "php 8.1 compatibility": "patches/des-connector-php-compat.patch"
-            },
-            "drupal/ultimate_cron": {
-              "d.o. #3351276": "https://www.drupal.org/files/issues/2023-04-03/3351276-4.patch"
-            },
-            "npm-asset/anchor-js": {
-                "remove font-face": "patches/remove-anchorjs-fontface.patch"
-            }
-        },
+        "patches-file": "composer.patches.json",
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,0 +1,29 @@
+{
+  "patches": {
+    "drupal/core": {
+      "d.o. 3400204": "https://www.drupal.org/files/issues/2023-11-23/claro-ck5-long-url.patch"
+    },
+    "drupal/elasticsearch_connector": {
+      "Preserve ES index settings": "https://www.drupal.org/files/issues/2020-01-28/3109361-elasticsearch_connector-preserve-index-settings-1.patch",
+      "d.o. #3106003 - Content access fixes": "https://www.drupal.org/files/issues/2021-01-12/missing-special-fields-3106003-8.patch",
+      "d.o. #3194318 - More robust language filtering": "https://www.drupal.org/files/issues/2021-01-25/3194318-hypen-lang-5.patch",
+      "d.o. #3014805 - Views filtering with facets": "https://www.drupal.org/files/issues/2019-12-20/elasticsearch_connector-facet_OR_global_aggregation_does_not_take_views_filter_into_account-3014805-15.patch",
+      "d.o. #2952301": "https://www.drupal.org/files/issues/2021-03-11/elasticsearch_connector_luceneFlattenKeys--2952301-14.patch"
+    },
+    "drupal/entity_reference_revisions": {
+      "d.o. 2799479": "https://www.drupal.org/files/issues/2022-06-01/entity_reference_revisions-relationship_host_id-2799479-176.patch"
+    },
+    "drupal/google_analytics": {
+      "d.o #3373921": "https://www.drupal.org/files/issues/2023-08-07/google-analytics-issues-3373921-cannot-install-from-existing-config-11.patch"
+    },
+    "nodespark/des-connector": {
+      "php 8.1 compatibility": "patches/des-connector-php-compat.patch"
+    },
+    "drupal/ultimate_cron": {
+      "d.o. #3351276": "https://www.drupal.org/files/issues/2023-04-03/3351276-4.patch"
+    },
+    "npm-asset/anchor-js": {
+      "remove font-face": "patches/remove-anchorjs-fontface.patch"
+    }
+  }
+}


### PR DESCRIPTION
This is a nice little improvement that I include in all my Drupal projects. It is much easier to manage patches in a dedicated external file than editing the root `composer.json`.

@see https://github.com/cweagans/composer-patches/blob/1.x/README.md#using-an-external-patch-file