### PR TITLE
Fix lock pages on translatin nodes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -67,7 +67,7 @@
             "version": "6.x-dev",
             "source": {
                 "type": "git",
-                "url": "git@github.com:FortAwesome/Font-Awesome.git",
+                "url": "https://github.com/FortAwesome/Font-Awesome.git",
                 "reference": "d02961b018153506364077343b0edcde0a39d27e"
             },
             "dist": {
@@ -15157,7 +15157,7 @@
             "version": "2.2.0",
             "source": {
                 "type": "git",
-                "url": "git@gitlab.com:weitzman/drupal-test-traits.git",
+                "url": "https://git.drupalcode.org/project/dtt/",
                 "reference": "9ef44f5cd5eef942c84f2d2ffd21734944d566f8"
             },
             "dist": {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -2,7 +2,8 @@
   "patches": {
     "drupal/core": {
       "d.o. 3400204": "https://www.drupal.org/files/issues/2023-11-23/claro-ck5-long-url.patch",
-      "d.o. #3315245": "patches/2938.patch"
+      "d.o. #3315245": "patches/2938.patch",
+      "d.o. #2351685": "https://www.drupal.org/files/issues/2023-02-03/2351685-22.patch"
     },
     "drupal/elasticsearch_connector": {
       "Preserve ES index settings": "https://www.drupal.org/files/issues/2020-01-28/3109361-elasticsearch_connector-preserve-index-settings-1.patch",

--- a/web/modules/custom/server_general/server_general.module
+++ b/web/modules/custom/server_general/server_general.module
@@ -240,7 +240,7 @@ function server_general_form_alter(array &$form, FormStateInterface $form_state)
 /**
  * Implements hook_module_implements_alter().
  */
-function server_general_module_implements_alter(&$implementations, $hook) {
+function server_general_module_implements_alter(array &$implementations, string $hook) {
   if ($hook == 'form_alter' && isset($implementations['server_general'])) {
     // Move this module's implementation of form_alter to the end of the list.
     // We're doing this so that we can override

--- a/web/modules/custom/server_general/server_general.module
+++ b/web/modules/custom/server_general/server_general.module
@@ -276,24 +276,22 @@ function server_general_entity_operation_alter(array &$operations, EntityInterfa
  */
 function server_general_content_translation_overview_alter(array $build, EntityInterface $entity) {
   if (!$entity instanceof NodeInterface || $entity->bundle() !== 'landing_page') {
+    // Not a Landing page.
     return;
   }
   /** @var \Drupal\server_general\LockedPages $locked_pages_service */
   $locked_pages_service = \Drupal::service('server_general.locked_pages');
 
-  // Check if node is locked or not.
   /** @var \Drupal\node\NodeInterface $entity */
   if (!$locked_pages_service->isNodeLocked($entity)) {
+    // Node isn't locked.
     return;
   }
-  // Check if content translations table has rows.
   if (!isset($build['content_translation_overview']['#rows'])) {
+    // There's no content to translate.
     return;
   }
   $content_translation_overview_rows = &$build['content_translation_overview']['#rows'];
-  if (empty($content_translation_overview_rows)) {
-    return;
-  }
   // Check for each language and unset delete operation.
   // Delete operation will exist only if node translation exists for
   // given language.

--- a/web/modules/custom/server_general/server_general.module
+++ b/web/modules/custom/server_general/server_general.module
@@ -231,7 +231,24 @@ function server_general_form_alter(array &$form, FormStateInterface $form_state)
   }
 
   unset($form['actions']['delete']);
+  // Unset "Delete translation" button.
+  // @See server_general_module_implements_alter().
+  unset($form['actions']['delete_translation']);
   $form['status']['#access'] = FALSE;
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function server_general_module_implements_alter(&$implementations, $hook) {
+  if ($hook == 'form_alter' && isset($implementations['server_general'])) {
+    // Move this module's implementation of form_alter to the end of the list.
+    // We're doing this so that we can override
+    // "content_translation_form_alter()" in our hook_form_alter.
+    $hookInit = $implementations['server_general'];
+    unset($implementations['server_general']);
+    $implementations['server_general'] = $hookInit;
+  }
 }
 
 /**

--- a/web/modules/custom/server_general/server_general.module
+++ b/web/modules/custom/server_general/server_general.module
@@ -245,9 +245,9 @@ function server_general_module_implements_alter(&$implementations, $hook) {
     // Move this module's implementation of form_alter to the end of the list.
     // We're doing this so that we can override
     // "content_translation_form_alter()" in our hook_form_alter.
-    $hookInit = $implementations['server_general'];
+    $hook_init = $implementations['server_general'];
     unset($implementations['server_general']);
-    $implementations['server_general'] = $hookInit;
+    $implementations['server_general'] = $hook_init;
   }
 }
 
@@ -275,7 +275,7 @@ function server_general_entity_operation_alter(array &$operations, EntityInterfa
  * Implements hook_content_translation_overview_alter().
  */
 function server_general_content_translation_overview_alter(array $build, EntityInterface $entity) {
-  if ($entity->bundle() !== 'landing_page') {
+  if (!$entity instanceof NodeInterface || $entity->bundle() !== 'landing_page') {
     return;
   }
   /** @var \Drupal\server_general\LockedPages $locked_pages_service */
@@ -299,11 +299,9 @@ function server_general_content_translation_overview_alter(array $build, EntityI
   // given language.
   foreach ($content_translation_overview_rows as &$language_data) {
     foreach ($language_data as &$element) {
-      if (is_array($element) && isset($element['data']['#type']) && $element['data']['#type'] === 'operations') {
-        // Check if the "delete" operation exists, then unset it.
-        if (isset($element['data']['#links']['delete'])) {
-          unset($element['data']['#links']['delete']);
-        }
+      // Check if the "delete" operation exists, then unset it.
+      if (is_array($element) && isset($element['data']['#type']) && $element['data']['#type'] === 'operations' && isset($element['data']['#links']['delete'])) {
+        unset($element['data']['#links']['delete']);
       }
     }
   }

--- a/web/modules/custom/server_general/server_general.module
+++ b/web/modules/custom/server_general/server_general.module
@@ -272,6 +272,44 @@ function server_general_entity_operation_alter(array &$operations, EntityInterfa
 }
 
 /**
+ * Implements hook_content_translation_overview_alter().
+ */
+function server_general_content_translation_overview_alter(array $build, EntityInterface $entity) {
+  if ($entity->bundle() !== 'landing_page') {
+    return;
+  }
+  /** @var \Drupal\server_general\LockedPages $locked_pages_service */
+  $locked_pages_service = \Drupal::service('server_general.locked_pages');
+
+  // Check if node is locked or not.
+  /** @var \Drupal\node\NodeInterface $entity */
+  if (!$locked_pages_service->isNodeLocked($entity)) {
+    return;
+  }
+  // Check if content translations table has rows.
+  if (!isset($build['content_translation_overview']['#rows'])) {
+    return;
+  }
+  $content_translation_overview_rows = &$build['content_translation_overview']['#rows'];
+  if (empty($content_translation_overview_rows)) {
+    return;
+  }
+  // Check for each language and unset delete operation.
+  // Delete operation will exist only if node translation exists for
+  // given language.
+  foreach ($content_translation_overview_rows as &$language_data) {
+    foreach ($language_data as &$element) {
+      if (is_array($element) && isset($element['data']['#type']) && $element['data']['#type'] === 'operations') {
+        // Check if the "delete" operation exists, then unset it.
+        if (isset($element['data']['#links']['delete'])) {
+          unset($element['data']['#links']['delete']);
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_menu_local_tasks_alter().
  */
 function server_general_menu_local_tasks_alter(array &$data, string $route_name): void {

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeLandingPageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeLandingPageTest.php
@@ -145,6 +145,20 @@ class ServerGeneralNodeLandingPageTest extends ServerGeneralNodeTestBase {
     $this->drupalGet("/node/{$node->id()}/delete");
     $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
 
+    // Test translations.
+    $node_es = $node->addTranslation('es', $node->toArray());
+    $node_es->setTitle('Not locked page ES');
+    $node_es->save();
+
+    $this->drupalGet("/node/{$node->id()}/translations");
+    $this->assertSession()->pageTextContains('Translations of');
+    $this->assertSession()->elementTextNotContains('css', 'table', 'Delete');
+
+    $this->drupalGet($node_es->toUrl('edit-form'));
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    // "Delete translations" button shouldn't exists if page is locked.
+    $this->assertSession()->elementNotExists('css', '#edit-delete-translation');
+
     // Check locked node for anonymous.
     $this->drupalLogout();
 

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeLandingPageTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeLandingPageTest.php
@@ -156,7 +156,7 @@ class ServerGeneralNodeLandingPageTest extends ServerGeneralNodeTestBase {
 
     $this->drupalGet($node_es->toUrl('edit-form'));
     $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
-    // "Delete translations" button shouldn't exists if page is locked.
+    // "Delete translation" button shouldn't exists if page is locked.
     $this->assertSession()->elementNotExists('css', '#edit-delete-translation');
 
     // Check locked node for anonymous.


### PR DESCRIPTION
#643 

- [x] unset "Delete translation" button on node translation edit form if node is locked
- [x] install [patch](https://www.drupal.org/project/drupal/issues/2351685) in order to add `hook_content_translation_overview_alter`
- [x] alter content translation overview page (which isn't a form) and unset `delete` operation for translations if node is locked
- [x] tests


https://github.com/Gizra/drupal-starter/assets/34510055/d025750f-81c7-4330-993d-56defa55a7e8

