### PR TITLE
CKEditor5 fix broken layout with Claro admin theme

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -67,7 +67,7 @@
             "version": "6.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FortAwesome/Font-Awesome.git",
+                "url": "git@github.com:FortAwesome/Font-Awesome.git",
                 "reference": "d02961b018153506364077343b0edcde0a39d27e"
             },
             "dist": {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -2,7 +2,8 @@
   "patches": {
     "drupal/core": {
       "d.o. #3315245": "patches/2938.patch",
-      "d.o. #2351685": "https://www.drupal.org/files/issues/2023-02-03/2351685-22.patch"
+      "d.o. #2351685": "https://www.drupal.org/files/issues/2023-02-03/2351685-22.patch",
+      "d.o. 3400204": "https://www.drupal.org/files/issues/2024-06-27/3400204-claro-layout-overflow-fix-2.patch"
     },
     "drupal/elasticsearch_connector": {
       "Preserve ES index settings": "https://www.drupal.org/files/issues/2020-01-28/3109361-elasticsearch_connector-preserve-index-settings-1.patch",


### PR DESCRIPTION
#681

- [x] fix claro broken layout for CKE5 with long strings used inside editor (both default and source editor modes)

Default editor|Source editor
-|-
![ds_cke5_claro_broken_layout_fix_default_editor](https://github.com/Gizra/drupal-starter/assets/34510055/f859ce31-f27c-45f4-8ff1-49064ac69245)|![ds_cke5_claro_broken_layout_fix_source_editor](https://github.com/Gizra/drupal-starter/assets/34510055/14b29af7-0d07-4392-8b8f-2692be001ad9)
