### PR TITLE
Use `testdox` coherently for `phpunit`

### DIFF
--- a/ci-scripts/test_phpunit.sh
+++ b/ci-scripts/test_phpunit.sh
@@ -4,6 +4,6 @@ set -e
 # -------------------------------------------------- #
 # Run PHPUnit tests
 # -------------------------------------------------- #
-ddev phpunit --do-not-cache-result --testdox || (ddev drush watchdog-show --count=1000 && exit 1)
+ddev phpunit --do-not-cache-result || (ddev drush watchdog-show --count=1000 && exit 1)
 
 exit 0

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
 <!-- ProcessIsolation: Runs each test in a new PHP thread when set to true.
      This ensures that PHP memory limit is not reached during tests as the
      number of tests build up over time in the project. -->
-<phpunit bootstrap=".bootstrap-fast.php" processIsolation="true">
+<phpunit bootstrap=".bootstrap-fast.php" processIsolation="true" testdox="true">
   <php>
     <env name="DTT_BASE_URL" value="http://web"/>
     <env name="DTT_API_URL" value="http://localhost:9222"/>


### PR DESCRIPTION
For very large test suites, on local, it is annoying that I need to wait the completion of the test suite to know what tests failed. `testdox` does exactly that.


## Status
![image](https://github.com/user-attachments/assets/6f898151-1b13-4931-abd5-4f95909b15d5)
