### PR TITLE
Increase database log retention

### DIFF
--- a/config/sync/dblog.settings.yml
+++ b/config/sync/dblog.settings.yml
@@ -1,3 +1,3 @@
-row_limit: 1000
+row_limit: 50000
 _core:
   default_config_hash: e883aGsrt1wFrsydlYU584PZONCSfRy0DtkZ9KzHb58

--- a/config/sync/dblog.settings.yml
+++ b/config/sync/dblog.settings.yml
@@ -1,3 +1,3 @@
-row_limit: 50000
+row_limit: 100000
 _core:
   default_config_hash: e883aGsrt1wFrsydlYU584PZONCSfRy0DtkZ9KzHb58


### PR DESCRIPTION
When there's an anomaly on a client site, we'd like to be able to trace back DBlog messages. In some cases, we already increased it. With server-side Rollbar problems we have, this is even more important, I think.