### PR TITLE
Recent News views page shows all translations

### DIFF
--- a/config/sync/views.view.news.yml
+++ b/config/sync/views.view.news.yml
@@ -201,6 +201,48 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
         options:


### PR DESCRIPTION
While working on a https://ns2024.drupal.rs/en we realized that News views page isn't filtering content per current page language but shows all translations.

- [x] filter recent News per current user translation language

![ds_news](https://github.com/user-attachments/assets/16889411-9e79-43a0-83b5-7f83a8b2ec86)

