### PR TITLE
Paragraph reference sanity

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphReferenceSanity.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphReferenceSanity.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+/**
+ * Tests paragraph reference fields.
+ */
+class ServerGeneralParagraphReferenceSanity extends ServerGeneralTestBase {
+
+  /**
+   * Checks that all paragraph reference fields are entity reference revisions.
+   */
+  public function testParagraphReferenceFields() {
+    $em = \Drupal::entityTypeManager();
+    $field_configs = $em->getStorage('field_config')->loadMultiple();
+
+    foreach ($field_configs as $id => $field_config) {
+      $storage_definition = $field_config->getFieldStorageDefinition();
+      $target_type = $storage_definition->getSetting('target_type');
+
+      if ($target_type !== 'paragraph') {
+        continue;
+      }
+
+      $field_type = $field_config->getType();
+      $this->assertEquals('entity_reference_revisions', $field_type, sprintf("Field %s referencing paragraphs must be of type 'entity_reference_revisions', not '%s'", $id, $field_type));
+    }
+  }
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphReferenceSanityTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphReferenceSanityTest.php
@@ -11,12 +11,10 @@ class ServerGeneralParagraphReferenceSanityTest extends ServerGeneralTestBase {
    * Checks that all paragraph reference fields are entity reference revisions.
    */
   public function testParagraphReferenceFields() {
-    $em = \Drupal::entityTypeManager();
-    $field_configs = $em->getStorage('field_config')->loadMultiple();
+    $field_configs = \Drupal::entityTypeManager()->getStorage('field_config')->loadMultiple();
 
     foreach ($field_configs as $id => $field_config) {
-      $storage_definition = $field_config->getFieldStorageDefinition();
-      $target_type = $storage_definition->getSetting('target_type');
+      $target_type = $field_config->getFieldStorageDefinition()->getSetting('target_type');
 
       if ($target_type !== 'paragraph') {
         continue;

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphReferenceSanityTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralParagraphReferenceSanityTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\server_general\ExistingSite;
 /**
  * Tests paragraph reference fields.
  */
-class ServerGeneralParagraphReferenceSanity extends ServerGeneralTestBase {
+class ServerGeneralParagraphReferenceSanityTest extends ServerGeneralTestBase {
 
   /**
    * Checks that all paragraph reference fields are entity reference revisions.


### PR DESCRIPTION
Make sure we avoid Orphaned paragraph warnings for all kind of paragraph references by a test for this.