### PR TITLE
Pantheon default config fixes for PHP and Solr

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "drupal/redirect": "^1.6",
         "drupal/redis": "^1.7",
         "drupal/search_api": "^1.18",
+        "drupal/search_api_pantheon": "^8.2",
         "drupal/search_api_solr": "^4.3.2",
         "drupal/seckit": "^2.0.3",
         "drupal/select2": "^1.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42705499ba797a0ba40fd9e9ed194cfd",
+    "content-hash": "e7fd38f052e2cd48bbd7fbe28e8ac69f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5044,6 +5044,145 @@
             }
         },
         {
+            "name": "drupal/search_api_pantheon",
+            "version": "8.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/search_api_pantheon.git",
+                "reference": "8.2.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/search_api_pantheon-8.2.2.zip",
+                "reference": "8.2.2",
+                "shasum": "d850a1c64460301b715533bdeea2c464c4454090"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10",
+                "drupal/search_api_solr": "^4.3",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": "^6.5.7|^7.5",
+                "http-interop/http-factory-guzzle": "^1.0",
+                "kint-php/kint": "^4.1|^5",
+                "php": ">=7.4",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/finder": "^4.4|^5|^6",
+                "symfony/yaml": "^4.4|^5|^6"
+            },
+            "require-dev": {
+                "consolidation/robo": "^3.0",
+                "czproject/git-php": "^4.0",
+                "drupal/coder": "@stable",
+                "drupal/search_api_solr": "*",
+                "phpunit/phpunit": "@stable",
+                "psy/psysh": "@stable",
+                "squizlabs/php_codesniffer": "@stable"
+            },
+            "suggest": {
+                "drupal/facets": "^1.8",
+                "drupal/search_api_autocomplete": "^1",
+                "drupal/search_api_page": "^1.0",
+                "drupal/search_api_spellcheck": "^3",
+                "kint-php/kint": "@stable"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.2.2",
+                    "datestamp": "1732037989",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^10"
+                    }
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Drupal\\search_api_pantheon\\": "src/",
+                    "Drupal\\search_api_pantheon\\tests\\": "tests/",
+                    "Drupal\\search_api\\": "vendor/drupal/search_api/src/",
+                    "Drupal\\search_api_solr\\": "vendor/drupal/search_api_solr/src/"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "scripts": {
+                "code:test": [
+                    "vendor/bin/phpunit -c ./phpunit.xml"
+                ],
+                "code:fix": [
+                    "vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer",
+                    "vendor/bin/phpcbf . --ignore=RoboFile.php,vendor src modules"
+                ],
+                "code:lint": [
+                    "vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer",
+                    "vendor/bin/phpcs --ignore=RoboFile.php,vendor . "
+                ],
+                "pre-commit": [
+                    "composer validate --strict",
+                    "@code:fix",
+                    "@code:lint",
+                    "@code:test"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "damienmckenna",
+                    "homepage": "https://www.drupal.org/user/108450"
+                },
+                {
+                    "name": "Ec1ipsis",
+                    "homepage": "https://www.drupal.org/user/1600400"
+                },
+                {
+                    "name": "greg.1.anderson",
+                    "homepage": "https://www.drupal.org/user/438598"
+                },
+                {
+                    "name": "jazzsequence",
+                    "homepage": "https://www.drupal.org/user/3713093"
+                },
+                {
+                    "name": "kporras07",
+                    "homepage": "https://www.drupal.org/user/1349780"
+                },
+                {
+                    "name": "pantheon-ci",
+                    "homepage": "https://www.drupal.org/user/3735947"
+                },
+                {
+                    "name": "pwtyler",
+                    "homepage": "https://www.drupal.org/user/3835268"
+                },
+                {
+                    "name": "stevector",
+                    "homepage": "https://www.drupal.org/user/179805"
+                },
+                {
+                    "name": "stovak",
+                    "homepage": "https://www.drupal.org/user/1074930"
+                },
+                {
+                    "name": "sumitmadan",
+                    "homepage": "https://www.drupal.org/user/1538790"
+                }
+            ],
+            "description": "Connection module for Pantheon Search (solr 8)",
+            "homepage": "https://www.drupal.org/project/search_api_pantheon",
+            "support": {
+                "source": "https://git.drupalcode.org/project/search_api_pantheon"
+            }
+        },
+        {
             "name": "drupal/search_api_solr",
             "version": "4.3.5",
             "source": {
@@ -6739,6 +6878,129 @@
                 }
             ],
             "time": "2023-11-28T21:12:40+00:00"
+        },
+        {
+            "name": "http-interop/http-factory-guzzle",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-factory-guzzle.git",
+                "reference": "8f06e92b95405216b237521cc64c804dd44c4a81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-factory-guzzle/zipball/8f06e92b95405216b237521cc64c804dd44c4a81",
+                "reference": "8f06e92b95405216b237521cc64c804dd44c4a81",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^1.7||^2.0",
+                "php": ">=7.3",
+                "psr/http-factory": "^1.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "^1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "phpunit/phpunit": "^9.5"
+            },
+            "suggest": {
+                "guzzlehttp/psr7": "Includes an HTTP factory starting in version 2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Factory\\Guzzle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "An HTTP Factory using Guzzle PSR7",
+            "keywords": [
+                "factory",
+                "http",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/http-interop/http-factory-guzzle/issues",
+                "source": "https://github.com/http-interop/http-factory-guzzle/tree/1.2.0"
+            },
+            "time": "2021-07-21T13:50:14+00:00"
+        },
+        {
+            "name": "kint-php/kint",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kint-php/kint.git",
+                "reference": "8c5ec370c3382ceae0b88e91f9bbb00e6bb4f93b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kint-php/kint/zipball/8c5ec370c3382ceae0b88e91f9bbb00e6bb4f93b",
+                "reference": "8c5ec370c3382ceae0b88e91f9bbb00e6bb4f93b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "phpspec/prophecy-phpunit": "^2",
+                "phpunit/phpunit": "^9",
+                "seld/phar-utils": "^1",
+                "symfony/finder": ">=4.0",
+                "vimeo/psalm": "^5"
+            },
+            "suggest": {
+                "kint-php/kint-helpers": "Provides extra helper functions",
+                "kint-php/kint-twig": "Provides d() and s() functions in twig templates"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "init.php"
+                ],
+                "psr-4": {
+                    "Kint\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Vollebregt",
+                    "homepage": "https://github.com/jnvsor"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/kint-php/kint/graphs/contributors"
+                }
+            ],
+            "description": "Kint - debugging tool for PHP developers",
+            "homepage": "https://kint-php.github.io/kint/",
+            "keywords": [
+                "debug",
+                "kint",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/kint-php/kint/issues",
+                "source": "https://github.com/kint-php/kint/tree/5.1.1"
+            },
+            "time": "2024-04-26T14:20:09+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -72,6 +72,7 @@ module:
   redis: 0
   responsive_image: 0
   search_api: 0
+  search_api_pantheon: 0
   search_api_solr: 0
   seckit: 0
   select2: 0

--- a/config/sync/search_api.server.pantheon_solr8.yml
+++ b/config/sync/search_api.server.pantheon_solr8.yml
@@ -1,0 +1,71 @@
+uuid: b3f1db55-8e86-4cf5-8ff2-6c1275c9eac4
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api_solr.solr_cache.cache_document_default_7_0_0
+    - search_api_solr.solr_cache.cache_fieldvalue_default_7_0_0
+    - search_api_solr.solr_cache.cache_filter_default_7_0_0
+    - search_api_solr.solr_cache.cache_persegfilter_default_7_0_0
+    - search_api_solr.solr_cache.cache_queryresult_default_7_0_0
+    - search_api_solr.solr_field_type.text_ar_7_0_0
+    - search_api_solr.solr_field_type.text_edge_und_7_0_0
+    - search_api_solr.solr_field_type.text_edgestring_und_6_0_0
+    - search_api_solr.solr_field_type.text_en_7_0_0
+    - search_api_solr.solr_field_type.text_es_7_0_0
+    - search_api_solr.solr_field_type.text_ngram_und_7_0_0
+    - search_api_solr.solr_field_type.text_ngramstring_und_6_0_0
+    - search_api_solr.solr_field_type.text_phonetic_en_7_0_0
+    - search_api_solr.solr_field_type.text_phonetic_es_7_0_0
+    - search_api_solr.solr_field_type.text_phonetic_und_7_0_0
+    - search_api_solr.solr_field_type.text_string_und_6_0_0
+    - search_api_solr.solr_field_type.text_und_7_0_0
+    - search_api_solr.solr_request_dispatcher.request_dispatcher_httpcaching_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_autocomplete_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_elevate_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_extract_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_mlt_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_select_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_spell_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_suggest_default_7_0_0
+    - search_api_solr.solr_request_handler.request_handler_tvrh_default_7_0_0
+  module:
+    - search_api_pantheon
+    - search_api_solr
+_core:
+  default_config_hash: 5Q1ZlUpNUSc4w8A7wHv4BG7qzalfvXHqEkyI6L60FXc
+id: pantheon_solr8
+name: 'Pantheon Search'
+description: ''
+backend: search_api_solr
+backend_config:
+  connector: pantheon
+  connector_config:
+    timeout: 5
+    index_timeout: 5
+    optimize_timeout: 10
+    finalize_timeout: 30
+    skip_schema_check: true
+    solr_version: '8'
+    http_method: AUTO
+    commit_within: 1000
+    jmx: false
+    jts: false
+    solr_install_dir: ''
+  disabled_field_types: {  }
+  disabled_caches: {  }
+  disabled_request_handlers:
+    - request_handler_replicationslave_default_7_0_0
+    - request_handler_replicationmaster_default_7_0_0
+  disabled_request_dispatchers:
+    - request_dispatcher_httpcachingnever_default_7_0_0
+  rows: 10
+  index_single_documents_fallback_count: 10
+  retrieve_data: false
+  highlight_data: false
+  fallback_multiple: false
+  server_prefix: ''
+  domain: generic
+  environment: default
+  optimize: false
+  site_hash: false

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,5 +1,5 @@
 api_version: 1
 web_docroot: true
 build_step: false
-php_version: 8.2
+php_version: 8.3
 drush_version: 10

--- a/pantheon_template/pantheon.yml
+++ b/pantheon_template/pantheon.yml
@@ -1,10 +1,12 @@
 api_version: 1
 web_docroot: true
 build_step: false
-php_version: 8.2
+php_version: 8.3
 enforce_https: transitional
+search:
+  version: 8
 database:
-  version: 10.4
+  version: 10.6
 drush_version: 10
 protected_web_paths:
   - /private/

--- a/web/sites/default/settings.pantheon.php
+++ b/web/sites/default/settings.pantheon.php
@@ -137,5 +137,5 @@ if (file_exists(__DIR__ . '/settings.fast404.php')) {
 }
 
 $config['search_api.index.server_dev']['server'] = 'pantheon_solr8';
-// This only exists at DDEV.
+// As we push to Solr config of DDEV to Pantheon as well, we disable it here.
 $config['search_api.server.solr']['status'] = FALSE;

--- a/web/sites/default/settings.pantheon.php
+++ b/web/sites/default/settings.pantheon.php
@@ -137,3 +137,5 @@ if (file_exists(__DIR__ . '/settings.fast404.php')) {
 }
 
 $config['search_api.index.server_dev']['server'] = 'pantheon_solr8';
+// This only exists at DDEV.
+$config['search_api.server.solr']['status'] = FALSE;

--- a/web/sites/default/settings.pantheon.php
+++ b/web/sites/default/settings.pantheon.php
@@ -135,3 +135,5 @@ if (file_exists('/files/private/secrets.json')) {
 if (file_exists(__DIR__ . '/settings.fast404.php')) {
   include __DIR__ . '/settings.fast404.php';
 }
+
+$config['search_api.index.server_dev']['server'] = 'pantheon_solr8';


### PR DESCRIPTION
We must explicitly specify Solr 8, otherwise we get Solr 4, and cryptic error messages about incompatibility.