### PR TITLE
Robustness fixes for the deploy process

### DIFF
--- a/ci-scripts/prepare_deploy.sh
+++ b/ci-scripts/prepare_deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 cd "$TRAVIS_BUILD_DIR" || exit 1
 
@@ -18,7 +19,9 @@ if [ -z "$PANTHEON_GIT_URL" ]; then
   exit 1
 fi
 
-git clone "$PANTHEON_GIT_URL" -b master .pantheon
+if [[ ! -d .pantheon ]]; then
+  git clone "$PANTHEON_GIT_URL" -b master .pantheon
+fi
 
 ddev stop
 
@@ -28,7 +31,7 @@ ddev stop
 # and comma itself.
 # These could break the YAML/Bash syntax.
 # shellcheck disable=SC2001
-TRAVIS_COMMIT_MESSAGE=$(echo "$TRAVIS_COMMIT_MESSAGE" | sed -e 's/[{},&*?|<>=%@\"'\''`-]//g')
+TRAVIS_COMMIT_MESSAGE=$(echo "$TRAVIS_COMMIT_MESSAGE" | tr '\n' ' ' | sed -e 's/[{},&*?|<>=%@\"'\''`-]//g')
 ddev config global --web-environment-add="TRAVIS_COMMIT_MESSAGE=$TRAVIS_COMMIT_MESSAGE"
 ddev config global --web-environment-add="GITHUB_TOKEN=$GITHUB_TOKEN"
 if [ -n "${DEPLOY_EXCLUDE_WARNING}" ]; then


### PR DESCRIPTION
 - better readability of Travis output by using `-x` - knowing which command resulted in the given error message by printing the command itself automatically
 - remove newline from the Travis commit message, it can easily break Travis config syntax
 - do not try to clone the repo if it already exists (when Travis tries to retry the failed deploy)