### PR TITLE
Restore exclude list for requirement warnings

### DIFF
--- a/ci-scripts/prepare_deploy.sh
+++ b/ci-scripts/prepare_deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -x
 
 cd "$TRAVIS_BUILD_DIR" || exit 1
 
@@ -18,7 +19,9 @@ if [ -z "$PANTHEON_GIT_URL" ]; then
   exit 1
 fi
 
-git clone "$PANTHEON_GIT_URL" -b master .pantheon
+if [[ ! -d .pantheon ]]; then
+  git clone "$PANTHEON_GIT_URL" -b master .pantheon
+fi
 
 ddev stop
 
@@ -28,7 +31,7 @@ ddev stop
 # and comma itself.
 # These could break the YAML/Bash syntax.
 # shellcheck disable=SC2001
-TRAVIS_COMMIT_MESSAGE=$(echo "$TRAVIS_COMMIT_MESSAGE" | sed -e 's/[{},&*?|<>=%@\"'\''`-]//g')
+TRAVIS_COMMIT_MESSAGE=$(echo "$TRAVIS_COMMIT_MESSAGE" | tr '\n' ' ' | sed -e 's/[{},&*?|<>=%@\"'\''`-]//g')
 ddev config global --web-environment-add="TRAVIS_COMMIT_MESSAGE=$TRAVIS_COMMIT_MESSAGE"
 ddev config global --web-environment-add="GITHUB_TOKEN=$GITHUB_TOKEN"
 if [ -n "${DEPLOY_EXCLUDE_WARNING}" ]; then

--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -510,8 +510,14 @@ trait DeploymentTrait {
       throw new \Exception("Cannot parse the response of terminus: " . serialize($parsed_output));
     }
 
+    $exclude = (string) getenv('DEPLOY_EXCLUDE_WARNING');
+    $exclude_list = explode('|', $exclude);
+
     foreach ($parsed_output as $requirement) {
       if ($requirement['severity'] !== 'Error') {
+        continue;
+      }
+      if (in_array($requirement['title'], $exclude_list) || in_array($requirement['value'], $exclude_list)) {
         continue;
       }
       $errors[] = '## ' . trim($requirement['title']) . "\n" . trim($requirement['value']);

--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -518,6 +518,7 @@ trait DeploymentTrait {
         continue;
       }
       if (in_array($requirement['title'], $exclude_list) || in_array($requirement['value'], $exclude_list)) {
+        // A warning we decided to exclude.
         continue;
       }
       $errors[] = '## ' . trim($requirement['title']) . "\n" . trim($requirement['value']);


### PR DESCRIPTION
https://github.com/Gizra/drupal-starter/commit/5e00cb0f382ed3c58f5f97ce46ed8a9e1b873ae7

It was implemented here, but when it was refactored to do JSON-based parsing, it was lost.