### PR TITLE
Focal point doesn't work properly when the preview image for the focal_point widget uses an image style that uses a focal_point image effect

### DIFF
--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.media.image.field_caption
     - field.field.media.image.field_media_credit
     - field.field.media.image.field_media_image
-    - image.style.large
+    - image.style.focal_point_preview
     - media.type.image
   module:
     - focal_point
@@ -44,7 +44,7 @@ content:
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: large
+      preview_image_style: focal_point_preview
       preview_link: true
       offsets: '50,50'
     third_party_settings: {  }

--- a/config/sync/image.style.focal_point_preview.yml
+++ b/config/sync/image.style.focal_point_preview.yml
@@ -1,0 +1,15 @@
+uuid: 32d5b905-057b-4821-bada-cc540b691491
+langcode: en
+status: true
+dependencies: {  }
+name: focal_point_preview
+label: 'Focal point preview'
+effects:
+  cb0af7d6-ac58-4b56-8aff-31cd808edf02:
+    uuid: cb0af7d6-ac58-4b56-8aff-31cd808edf02
+    id: image_scale
+    weight: 1
+    data:
+      width: 480
+      height: null
+      upscale: false


### PR DESCRIPTION
Reference: https://www.drupal.org/node/2872960

### Update:
- Added a new 'Focal point preview' image style with simple '480px width scale' effect.
- Update the Image field focal_point widget in Image media entity to use this image style.

Before|After
-|-
https://github.com/user-attachments/assets/689fa5b9-29f4-4039-8adb-44d73e69b3b6|https://github.com/user-attachments/assets/f6e09d3e-3504-488c-84d1-924ace42257a
