### PR TITLE
Replace bower/fontawesome with bower/font-awesome

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "bower-asset/fontawesome": "^6.4",
+        "bower-asset/font-awesome": "^6",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df3be6c7b511c748e9253b36d0bf2b93",
+    "content-hash": "f9f6072acf4161e747745b74a2e100c4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -63,17 +63,17 @@
             "time": "2023-11-14T13:51:46+00:00"
         },
         {
-            "name": "bower-asset/fontawesome",
-            "version": "6.x-dev",
+            "name": "bower-asset/font-awesome",
+            "version": "6.7.2",
             "source": {
                 "type": "git",
-                "url": "git@github.com:FortAwesome/Font-Awesome.git",
-                "reference": "d02961b018153506364077343b0edcde0a39d27e"
+                "url": "https://github.com/FortAwesome/Font-Awesome.git",
+                "reference": "af620534bfc3c2d4cbefcfeec29603bbe7809e64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/d02961b018153506364077343b0edcde0a39d27e",
-                "reference": "d02961b018153506364077343b0edcde0a39d27e"
+                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/af620534bfc3c2d4cbefcfeec29603bbe7809e64",
+                "reference": "af620534bfc3c2d4cbefcfeec29603bbe7809e64"
             },
             "type": "bower-asset"
         },
@@ -3402,20 +3402,20 @@
         },
         {
             "name": "drupal/google_analytics",
-            "version": "4.0.2",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/google_analytics.git",
-                "reference": "4.0.2"
+                "reference": "4.0.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/google_analytics-4.0.2.zip",
-                "reference": "4.0.2",
-                "shasum": "6deec511373e4659e42ff494c8729434728e37d7"
+                "url": "https://ftp.drupal.org/files/projects/google_analytics-4.0.3.zip",
+                "reference": "4.0.3",
+                "shasum": "faaae65a3b52d842ceef78fd2b2ef6344f3a21a0"
             },
             "require": {
-                "drupal/core": "^9.3 || ^10"
+                "drupal/core": "^9.5 || ^10 || ^11"
             },
             "require-dev": {
                 "drupal/token": "^1.7"
@@ -3423,8 +3423,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.0.2",
-                    "datestamp": "1662768595",
+                    "version": "4.0.3",
+                    "datestamp": "1734385014",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -16,9 +16,6 @@
     "drupal/entity_reference_revisions": {
       "d.o. #2799479": "https://www.drupal.org/files/issues/2022-06-01/entity_reference_revisions-relationship_host_id-2799479-176.patch"
     },
-    "drupal/google_analytics": {
-      "d.o #3373921": "https://www.drupal.org/files/issues/2023-08-07/google-analytics-issues-3373921-cannot-install-from-existing-config-11.patch"
-    },
     "nodespark/des-connector": {
       "php 8.1 compatibility": "patches/des-connector-php-compat.patch"
     },

--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -86,6 +86,8 @@ trait DeploymentTrait {
     'package-lock.json',
     'composer.json',
     'composer.lock',
+    'web/libraries/font-awesome/js-packages',
+    'web/libraries/font-awesome/metadata',
   ];
 
   /**

--- a/web/themes/custom/server_theme/server_theme.libraries.yml
+++ b/web/themes/custom/server_theme/server_theme.libraries.yml
@@ -47,7 +47,7 @@ opensans:
 font-awesome:
   css:
     theme:
-      /libraries/fontawesome/css/all.min.css: {}
+      /libraries/font-awesome/css/all.min.css: {}
 
 slick:
   remote: https://github.com/kenwheeler/slick


### PR DESCRIPTION
Sometimes we see:

```
Problem 1
    - Root composer.json requires bower-asset/fontawesome == 6.4.2.0 (exact version match), found bower-asset/fontawesome[dev-update-readme-logo, dev-master, dev-issue-18807, v1.0.0, 2.0.0, v3.0.0, ..., v3.2.1, v4.0.0, ..., 4.x-dev, 5.0.6, ..., 5.x-dev, 6.0.0, ..., 6.x-dev] but these do not match your constraint and are therefore not installable. Make sure you either fix the constraint or avoid updating this package to keep the one present in the lock file (bower-asset/fontawesome[6.4.2]).
```

But it seems there are 2
    
- https://asset-packagist.org/package/bower-asset/fontawesome
- https://asset-packagist.org/package/bower-asset/font-awesome

Today they are the same, but we have seem some discrepancy in the past.

