### PR TITLE
WIP: PHPStan rule to prevent `#theme` inside PEVB

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
   - vendor/mglaman/phpstan-drupal/extension.neon
   - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+  - web/modules/custom/server_general/phpstan-extension.neon
 parameters:
   level: 6
   reportUnmatchedIgnoredErrors: false

--- a/web/modules/custom/server_general/phpstan-extension.neon
+++ b/web/modules/custom/server_general/phpstan-extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: Drupal\server_general\PHPStan\NoThemeInEntityViewBuilderRule
+        tags:
+            - phpstan.rules.rule

--- a/web/modules/custom/server_general/src/PHPStan/NoThemeInEntityViewBuilderRule.php
+++ b/web/modules/custom/server_general/src/PHPStan/NoThemeInEntityViewBuilderRule.php
@@ -16,7 +16,7 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 class NoThemeInEntityViewBuilderRule implements Rule
 {
-  private const ERROR_MESSAGE = "Use of '#theme' is not allowed in EntityViewBuilder classes";
+  private const ERROR_MESSAGE = "Use of '#theme' is not allowed in Pluggable entity view builder `EntityViewBuilder` classes";
 
   public function getNodeType(): string
   {
@@ -52,8 +52,8 @@ class NoThemeInEntityViewBuilderRule implements Rule
 
   private function isEntityViewBuilder(ClassReflection $class): bool
   {
-    return $class->isSubclassOf('Drupal\Core\Entity\EntityViewBuilder') ||
-      $class->getName() === 'Drupal\Core\Entity\EntityViewBuilder';
+    return $class->isSubclassOf('Drupal\pluggable_entity_view_builder\EntityViewBuilder') ||
+      $class->getName() === 'Drupal\pluggable_entity_view_builder\EntityViewBuilder';
   }
 
   private function containsThemeKey(Array_ $node): bool

--- a/web/modules/custom/server_general/src/PHPStan/NoThemeInEntityViewBuilderRule.php
+++ b/web/modules/custom/server_general/src/PHPStan/NoThemeInEntityViewBuilderRule.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\server_general\PHPStan;
 
 use PhpParser\Node;

--- a/web/modules/custom/server_general/src/PHPStan/NoThemeInEntityViewBuilderRule.php
+++ b/web/modules/custom/server_general/src/PHPStan/NoThemeInEntityViewBuilderRule.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\server_general\PHPStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Array_>
+ */
+class NoThemeInEntityViewBuilderRule implements Rule
+{
+  private const ERROR_MESSAGE = "Use of '#theme' is not allowed in EntityViewBuilder classes";
+
+  public function getNodeType(): string
+  {
+    return Array_::class;
+  }
+
+  public function processNode(Node $node, Scope $scope): array
+  {
+    if (!$this->isInEntityViewBuilder($scope)) {
+      return [];
+    }
+
+    if ($this->containsThemeKey($node)) {
+      return [
+        RuleErrorBuilder::message(self::ERROR_MESSAGE)
+          ->line($node->getLine())
+          ->build()
+      ];
+    }
+
+    return [];
+  }
+
+  private function isInEntityViewBuilder(Scope $scope): bool
+  {
+    $class = $scope->getClassReflection();
+    if ($class === null) {
+      return false;
+    }
+
+    return $this->isEntityViewBuilder($class);
+  }
+
+  private function isEntityViewBuilder(ClassReflection $class): bool
+  {
+    return $class->isSubclassOf('Drupal\Core\Entity\EntityViewBuilder') ||
+      $class->getName() === 'Drupal\Core\Entity\EntityViewBuilder';
+  }
+
+  private function containsThemeKey(Array_ $node): bool
+  {
+    foreach ($node->items as $item) {
+      if ($item === null) {
+        continue;
+      }
+
+      if ($item->key instanceof Node\Scalar\String_ && $item->key->value === '#theme') {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
The goal is to get 

```php
<?php

namespace Drupal\server_general\Plugin\EntityViewBuilder;

use Drupal\Core\Entity\EntityViewBuilder;

class TestEntityViewBuilder extends EntityViewBuilder {
    public function build(array $build) {
        $build['#theme'] = 'test_theme'; // Should trigger the rule
        return $build;
    }
}
```

Produce something like 

```
Line   web/modules/custom/server_general/src/Plugin/EntityViewBuilder/TestEntityViewBuilder.php
----   -----------------------------------------------------------------------------------
10     Use of '#theme' is not allowed in EntityViewBuilder classes
```