### PR TITLE
Better secrets handling for Pantheon

### DIFF
--- a/.ddev/commands/web/terminus
+++ b/.ddev/commands/web/terminus
@@ -4,18 +4,26 @@
 ## Usage: terminus [flags] [args]
 ## Example: "ddev terminus remote:drush drupal-starter.live uli"
 
-# Function to check if the terminus-secrets-manager-plugin is installed.
+# Function to check if a specified plugin is installed.
 is_plugin_installed() {
-  terminus self:plugin:list | grep -q "terminus-secrets-manager-plugin"
+  local plugin_name="$1"
+  terminus self:plugin:list | grep -q "$plugin_name"
 }
 
-# Check if the first argument is in the "secret" namespace.
-if [[ $1 == secret:* ]]; then
-  # Check if the plugin is not installed
-  if ! is_plugin_installed; then
-    echo "Installing terminus-secrets-manager-plugin..."
-    terminus self:plugin:install terminus-secrets-manager-plugin
+# Function to install a specified plugin if it's not installed.
+install_plugin_if_missing() {
+  local plugin_name="$1"
+  if ! is_plugin_installed "$plugin_name"; then
+    echo "Installing $plugin_name..."
+    terminus self:plugin:install "$plugin_name"
   fi
+}
+
+# Secret Manager is rarely needed, this way we do not install it
+# again and again at the CI environment for instance.
+# Only when it's actually needed, we install it on-the-fly.
+if [[ $1 == secret:* ]]; then
+  install_plugin_if_missing "terminus-secrets-manager-plugin"
 fi
 
 # Run the terminus command with all provided arguments

--- a/.ddev/commands/web/terminus
+++ b/.ddev/commands/web/terminus
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Run terminus inside the web container
+## Usage: terminus [flags] [args]
+## Example: "ddev terminus remote:drush drupal-starter.live uli"
+
+terminus $@

--- a/.ddev/commands/web/terminus
+++ b/.ddev/commands/web/terminus
@@ -4,4 +4,19 @@
 ## Usage: terminus [flags] [args]
 ## Example: "ddev terminus remote:drush drupal-starter.live uli"
 
-terminus $@
+# Function to check if the terminus-secrets-manager-plugin is installed.
+is_plugin_installed() {
+  terminus self:plugin:list | grep -q "terminus-secrets-manager-plugin"
+}
+
+# Check if the first argument is in the "secret" namespace.
+if [[ $1 == secret:* ]]; then
+  # Check if the plugin is not installed
+  if ! is_plugin_installed; then
+    echo "Installing terminus-secrets-manager-plugin..."
+    terminus self:plugin:install terminus-secrets-manager-plugin
+  fi
+fi
+
+# Run the terminus command with all provided arguments
+terminus "$@"

--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -9,6 +9,9 @@ hooks:
     # Private files directory.
     - exec: mkdir -p /var/www/private
 
+    # Terminus secrets plugin.
+    - exec: terminus self:plugin:install terminus-secrets-manager-plugin
+
     # Create a private key for Two-factor Authentication if not yet added.
     - exec-host: ddev set-tfa-key
 

--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -9,9 +9,6 @@ hooks:
     # Private files directory.
     - exec: mkdir -p /var/www/private
 
-    # Terminus secrets plugin.
-    - exec: terminus self:plugin:install terminus-secrets-manager-plugin
-
     # Create a private key for Two-factor Authentication if not yet added.
     - exec-host: ddev set-tfa-key
 

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -267,11 +267,7 @@ corepack_enable: false
 # However, with "override_config: true" in a particular config.*.yaml file,
 # 'use_dns_when_possible: false' can override the existing values, and
 #
-hooks:
-  post-start:
-    # Terminus Secrets plugin.
-    - exec: terminus self:plugin:install terminus-secrets-manager-plugin
-
+#   post-start: []
 # or
 # web_environment: []
 # or

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -266,8 +266,12 @@ corepack_enable: false
 # and you can't erase existing hooks or all environment variables.
 # However, with "override_config: true" in a particular config.*.yaml file,
 # 'use_dns_when_possible: false' can override the existing values, and
-# hooks:
-#   post-start: []
+#
+hooks:
+  post-start:
+    # Terminus Secrets plugin.
+    - exec: terminus self:plugin:install terminus-secrets-manager-plugin
+
 # or
 # web_environment: []
 # or

--- a/README.md
+++ b/README.md
@@ -529,12 +529,22 @@ To import the config translations:
 
 ## Two-factor Authentication (TFA)
 
-TFA is enabled for the Administrator and Content editor users.
+TFA is disabled by default. Edit the [Pantheon-specific settings](https://github.com/Gizra/drupal-starter/blob/main/web/sites/default/settings.pantheon.php#L96) to activate it.
 The default settings under `/admin/config/people/tfa` define "Skip Validation" is 1. That is,
 when a privileged user will login, they must enable their TFA. Otherwise, on a second
 login, they will already be blocked. A site admin may reset their validation tries
 under the `/admin/people` page.
 The TFA method that is enabled is one that uses Google authenticator (or similar).
+
+You should set the TFA secret using:
+```bash
+ddev terminus secret:site:set gizra-drupal-starter tfa_key $(openssl rand -base64 32) --type=runtime --scope=web,user
+```
+
+If you need environment-based override, you can do the following:
+```bash
+ddev terminus secret:site:set gizra-drupal-starter.qa tfa_key $(openssl rand -base64 32)
+```
 
 ## WAF - Crowdsec
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The starter kit comes out of the box with Solr.
 It can happen that an index is polluted and Search API cannot restore it using "Delete all indexed items". Then there's a Drush command of the integration module to reset the index, drop all data inside:
 
 ```bash
-ddev exec terminus remote:drush gizra-drupal-starter.qa search-api-pantheon:force-cleanup
+ddev terminus remote:drush gizra-drupal-starter.qa search-api-pantheon:force-cleanup
 ```
 
 Then you can re-index the data and check the sanity of the search.
@@ -260,7 +260,7 @@ Then edit `scripts/mass_patch.config.sh` and add the proper project names.
 Then, you can create a new site in Pantheon which can also be done with a
 [terminus command](https://pantheon.io/docs/guides/drupal8-commandline):
 
-    ddev exec terminus site:create my-site "My Site" "Drupal 10 Start State"
+    ddev terminus site:create my-site "My Site" "Drupal 10 Start State"
 
 #### Change to nested docroot structure
 

--- a/web/sites/default/settings.pantheon.php
+++ b/web/sites/default/settings.pantheon.php
@@ -127,10 +127,10 @@ if (!empty($pantheon_env) && !empty($_ENV['CACHE_HOST'])) {
   $settings['cache']['bins']['form'] = 'cache.backend.database';
 }
 
-if (file_exists('/files/private/secrets.json')) {
-  $secrets = json_decode(file_get_contents('/files/private/secrets.json'), TRUE);
-  if (isset($secrets['tfa'])) {
-    putenv('TFA_KEY="' . $secrets['tfa'] . "\"");
+if (function_exists('pantheon_get_secret') ) {
+  $secret_value = pantheon_get_secret('tfa');
+  if (!empty($secret_value)) {
+    putenv('TFA_KEY="' . $secret_value . "\"");
   }
 }
 

--- a/web/sites/default/settings.pantheon.php
+++ b/web/sites/default/settings.pantheon.php
@@ -127,7 +127,7 @@ if (!empty($pantheon_env) && !empty($_ENV['CACHE_HOST'])) {
   $settings['cache']['bins']['form'] = 'cache.backend.database';
 }
 
-if (function_exists('pantheon_get_secret') ) {
+if (function_exists('pantheon_get_secret')) {
   $secret_value = pantheon_get_secret('tfa_key');
   if (!empty($secret_value)) {
     putenv('TFA_KEY="' . $secret_value . "\"");

--- a/web/sites/default/settings.pantheon.php
+++ b/web/sites/default/settings.pantheon.php
@@ -128,7 +128,7 @@ if (!empty($pantheon_env) && !empty($_ENV['CACHE_HOST'])) {
 }
 
 if (function_exists('pantheon_get_secret') ) {
-  $secret_value = pantheon_get_secret('tfa');
+  $secret_value = pantheon_get_secret('tfa_key');
   if (!empty($secret_value)) {
     putenv('TFA_KEY="' . $secret_value . "\"");
   }


### PR DESCRIPTION
#807 

## Status

```
gizra  drupal-starter  terminus remote:drush gizra-drupal-starter.qa php:eval 'print pantheon_get_secret("tfa_key");'
 [warning] This environment is in read-only Git mode. If you want to make changes to the codebase of this site (e.g. updating modules or plugins), you will need to toggle into read/write SFTP mode first.
12345678910XXXXXXXXXXXXXXXXXXXXXXXXX/Cs= [notice]
Command: gizra-drupal-starter.qa -- drush php:eval print pantheon_get_secret("tfa_key"); [Exit: 0] (Attempt 1/1)
```