### PR TITLE
Drop unlimited memory generally for PHP CLI

### DIFF
--- a/.ddev/commands/web/phpstan
+++ b/.ddev/commands/web/phpstan
@@ -4,4 +4,4 @@
 ## Usage: phpstan
 ## Example: "ddev phpstan"
 
-PHP_MEMORY_LIMIT=2G ./vendor/bin/phpstan --no-progress analyse -c phpstan.neon --level max
+PHP_MEMORY_LIMIT=2G ./vendor/bin/phpstan --no-progress analyse -c phpstan.neon

--- a/.ddev/commands/web/phpstan
+++ b/.ddev/commands/web/phpstan
@@ -4,4 +4,4 @@
 ## Usage: phpstan
 ## Example: "ddev phpstan"
 
-./vendor/bin/phpstan --no-progress analyse -c phpstan.neon
+PHP_MEMORY_LIMIT=2G ./vendor/bin/phpstan --no-progress analyse -c phpstan.neon --level max

--- a/.ddev/commands/web/phpunit
+++ b/.ddev/commands/web/phpunit
@@ -6,8 +6,8 @@
 
 if [ $# -eq 0 ]; then
   # If no arguments are provided, run non-Rollbar tests
-  ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=Rollbar
+  PHP_MEMORY_LIMIT=2G ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=Rollbar
 else
   # If arguments are provided, pass them to PHPUnit
-  ./vendor/bin/phpunit -c phpunit.xml.dist "$@"
+  PHP_MEMORY_LIMIT=2G ./vendor/bin/phpunit -c phpunit.xml.dist "$@"
 fi

--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -44,14 +44,6 @@ hooks:
     # @see https://www.drupal.org/node/947312
     - exec: drush user-block --uid=1
 
-    # Make sure PHP CLI has no memory limit, this is
-    # especially for unit testing.
-    # Web requests should be still limited, as the
-    # hosting environment won't provide unlimited
-    # memory either.
-    # @see https://github.com/drud/ddev/issues/1825#issuecomment-529964728
-    - exec: perl -pi -e 's/memory_limit.*$/memory_limit = -1/' /etc/php/${DDEV_PHP_VERSION}/cli/conf.d/*.ini
-
     # Login as AdminOne.
     - exec-host: ddev login
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/test_syntax.sh || travis_terminate 1;"
         - composer install
-        - PHP_MEMORY_LIMIT=2G ./vendor/bin/phpstan --no-progress analyse -c phpstan.neon --level max
+        - PHP_MEMORY_LIMIT=2G ./vendor/bin/phpstan --no-progress analyse -c phpstan.neon
 
     - stage: Lint
       name: Drupal coding standard

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       script:
         - "$TRAVIS_BUILD_DIR/ci-scripts/test_syntax.sh || travis_terminate 1;"
         - composer install
-        - vendor/bin/phpstan analyse -c phpstan.neon
+        - PHP_MEMORY_LIMIT=2G ./vendor/bin/phpstan --no-progress analyse -c phpstan.neon --level max
 
     - stage: Lint
       name: Drupal coding standard


### PR DESCRIPTION
It was a workaround, but now we have a solution to adjust the limit per-process.