### PR TITLE
Larger screen for browser-based test

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSelenium2TestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSelenium2TestBase.php
@@ -15,6 +15,18 @@ use weitzman\DrupalTestTraits\ExistingSiteSelenium2DriverTestBase;
 class ServerGeneralSelenium2TestBase extends ExistingSiteSelenium2DriverTestBase {
 
   /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $session = $this->getSession();
+    // Make takeScreenshot() more developer friendly, capture
+    // as many details as possible.
+    $session->resizeWindow(1900, 1900);
+  }
+
+  /**
    * Tear down and unset variables.
    *
    * This is needed in order to reduce the memory usage by PHPUnit.


### PR DESCRIPTION
```php
  public function testHomeFeaturedContent() {
    $this->drupalGet('<front>');
    /** @var \Drupal\FunctionalJavascriptTests\JSWebAssert $web_assert */
    $web_assert = $this->assertSession();

    $featured_content = $web_assert->waitForElement('css', '.paragraph--type--related-content');
    $this->assertNotNull($featured_content);
    $web_assert->elementTextContains('css', '.paragraph--type--related-content h2', 'Featured Content');
    // Slick is initialized.
    $carousel = $web_assert->waitForElement('css', '.paragraph--type--related-content .carousel-wrapper.slick-initialized');
    $this->assertNotNull($carousel);

    // Assert the current slide has the expected title.
    $web_assert->elementTextContains('css', '.paragraph--type--related-content .carousel-slide.slick-current', 'Current Digital Marketing Is Sports-Watching, Rather Than Marketing');
    // Click on the 2nd dot navigation.
    $dots_2 = $carousel->find('css', '.slick-dots li:nth-child(2)');
    $this->assertNotNull($dots_2);
    $dots_2->click();
    // Wait half sec for the JS and animation.
    $this->getSession()->wait(500);
    // Assert that the active slide is now different.
    $web_assert->elementTextContains('css', '.paragraph--type--related-content .carousel-slide.slick-current', 'Pandemic Moves Education Online');
    $this->takeScreenshot('homepage');
  }
```

## Before

![homepage1747123981](https://github.com/user-attachments/assets/6fb90446-74db-4f99-9c16-75c6064e820b)


## After

![homepage1747123829](https://github.com/user-attachments/assets/3d7e638e-518c-4119-9823-1edf3f4eca5b)
