### PR TITLE
Reload Solr upon DB clone - Pantheon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /web/themes/contrib/
 /web/profiles/contrib/
 /web/libraries/
-web/private/
 
 # Ignore sensitive information
 /web/sites/*/settings.php

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -3,3 +3,9 @@ web_docroot: true
 build_step: false
 php_version: 8.3
 drush_version: 10
+workflows:
+  clone_database:
+    after:
+      - type: webphp
+        description: Reload Solr after DB clone
+        script: private/scripts/reload_solr.php

--- a/pantheon_template/pantheon.yml
+++ b/pantheon_template/pantheon.yml
@@ -12,3 +12,9 @@ protected_web_paths:
   - /private/
   - /sites/default/files/private/
   - /sites/default/files/config/
+workflows:
+  clone_database:
+    after:
+      - type: webphp
+        description: Reload Solr after DB clone
+        script: private/scripts/reload_solr.php

--- a/web/private/scripts/reload_solr.php
+++ b/web/private/scripts/reload_solr.php
@@ -1,0 +1,3 @@
+<?php
+passthru('drush en search_api_solr_admin -y');
+passthru('drush solr-reload pantheon_solr8');


### PR DESCRIPTION
We faced with a strange bug after DB clone at a client project. It seems DB cloning makes Solr in a non-desired state. This is what the support recommended, to reload Solr. So we should automate it.