### PR TITLE
Fix exception message about directory being dirty

### DIFF
--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -240,7 +240,7 @@ trait DeploymentTrait {
 
     if ($result->getMessage()) {
       $this->say($result->getMessage());
-      throw new \Exception('The Pantheon directory is dirty. Please commit any pending changes.');
+      throw new \Exception('The project directory is dirty. Please commit any pending changes.');
     }
 
     $result = $this


### PR DESCRIPTION
At this time we are checking the status of the project, not the git repo in .pantheon dir, so message is misleading.