### PR TITLE
Remove global css library version

### DIFF
--- a/web/themes/custom/server_theme/server_theme.libraries.yml
+++ b/web/themes/custom/server_theme/server_theme.libraries.yml
@@ -1,5 +1,4 @@
 global-styling:
-  version: 1.0
   css:
     theme:
       dist/css/style.css: {}


### PR DESCRIPTION
Starting from Drupal 10.1.2, the version information within a library definition plays a critical role in generating a unique hash for aggregated files. Consequently, it is imperative that the "version" in a library definition is updated whenever a referenced CSS/JS file undergoes changes.

Alternatively, if the version is omitted, the prior behavior will apply, where the content of referenced CSS/JS files is utilized in the hash.

Incorrect usage of version information could lead to browser and edge cache invalidation issues.