### PR TITLE
Fix semver version in updater

### DIFF
--- a/robo-components/AutoUpdateTrait.php
+++ b/robo-components/AutoUpdateTrait.php
@@ -61,7 +61,13 @@ trait AutoUpdateTrait {
       if (in_array($current_branch, ['master', 'main'], TRUE)) {
         throw new \Exception("This command cannot be run on the {$current_branch} branch.");
       }
-
+      // Check if composer.lock has changes. Using the -W flag can
+      // result in modules already being updated.
+      $lock_changed = trim(`git status --porcelain composer.lock`);
+      if (!$lock_changed) {
+        $this->say($package . 'is already at version ' . $version);
+        continue;
+      }
       // Update successful, add composer.lock to staging area,
       // then commit it.
       $this->taskExec("git add composer.lock")->printOutput(TRUE)->run();

--- a/robo-components/AutoUpdateTrait.php
+++ b/robo-components/AutoUpdateTrait.php
@@ -20,6 +20,7 @@ trait AutoUpdateTrait {
     }
     $this->say("Update module is installed, checking status of projects.");
     $this->say("In case of some errors manually loading /admin/reports/updates can help.");
+    $this->yell("Don't forget to run ddev drush updb manually at the end!");
 
     if (!($available = update_get_available(TRUE))) {
       $this->say("Cannot fetch info about the releases.");

--- a/robo-components/AutoUpdateTrait.php
+++ b/robo-components/AutoUpdateTrait.php
@@ -39,7 +39,7 @@ trait AutoUpdateTrait {
         continue;
       }
       $version = $project['recommended'];
-      // Example input: "8.x-2.19"
+      // Example input: "8.x-2.19".
       if (preg_match('/^\d+\.x-(\d+)\.(\d+)$/', $project['recommended'], $matches)) {
         $major = $matches[1];
         $minor = $matches[2];


### PR DESCRIPTION
We need to use semver, instead of the legacy drupal versioning drupal provides on the status page.