### PR TITLE
Add a simple sitemap test to check all content types are indexed (or excluded)

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSimpleSitemapTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSimpleSitemapTest.php
@@ -11,9 +11,8 @@ use Drupal\node\Entity\NodeType;
  */
 class ServerGeneralSimpleSitemapTest extends ServerGeneralTestBase {
 
-  const EXCLUDED_TYPES = [
-    'some_node_type',
-  ];
+  // Node types that should be excluded.
+  const EXCLUDED_TYPES = [];
 
   /**
    * Verfies all non exluded content type are indexed by simple sitemap.


### PR DESCRIPTION
So when new content types are added they are not forgotten. Or they have to be explicitly ignored. 