### PR TITLE
More robust version number handling in auto update script.

### DIFF
--- a/robo-components/AutoUpdateTrait.php
+++ b/robo-components/AutoUpdateTrait.php
@@ -40,6 +40,12 @@ trait AutoUpdateTrait {
         continue;
       }
       $version = $project['recommended'];
+      // Version numbers in drupal can take several patterns. We need to derive
+      // the composer update command from any of them:
+      // 4.0.0 => ^4.0
+      // 4.0.0-alpha6 => ^4.0@alpha
+      // 8.x-4.0 => ^4.0
+      // 8.x-4.0-alpha6 => ^4.0@alpha.
       if (preg_match('/^(?:\d+\.x-)?(\d+)\.(\d+)(?:\.(\d+))?(?:-([A-Za-z0-9.-]+))?$/', trim($project['recommended']), $matches)) {
         // e.g., '8' or '2'.
         $major = $matches[1];


### PR DESCRIPTION
As the module version number can take several forms, we need to handle all cases and generate the required composer command.
E.g. 5.1.0., 8.x-4.1.0, 8.x-4.0-alpha6 etc.