### PR TITLE
Refactor Dockerfile to be more robust - layer caching issue

### DIFF
--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -4,5 +4,13 @@ FROM $BASE_IMAGE
 # For being able to optimize images as part of theme compilation, we install
 # extra tools here - in a non-interactive way, also trying to avoid extra
 # packages that would increase the image size.
-RUN DEBIAN_FRONTEND=noninteractive apt-get --fix-missing update || true
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confold" --no-install-recommends --no-install-suggests optipng jpegoptim
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      -o Dpkg::Options::="--force-confold" \
+      --no-install-recommends \
+      --no-install-suggests \
+      optipng \
+      jpegoptim; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes Docker build failures caused by outdated cached layers referencing non-existing package URLs.

## Changes
- Combine apt-get update and install into single RUN statement to prevent layer caching issues
- Remove `--fix-missing` and `|| true` which masked errors
- Add `set -eux` for better error handling
- Add cleanup steps (`apt-get clean`, `rm -rf /var/lib/apt/lists/*`) to reduce image size
- Format package list for better readability

This ensures the Docker build remains stable even when intermediate layers are outdated.