### PR TITLE
Fail phpunit parallel testing if a test fails

### DIFF
--- a/.ddev/commands/web/phpunit
+++ b/.ddev/commands/web/phpunit
@@ -4,6 +4,8 @@
 ## Usage: phpunit [arguments]
 ## Example: "ddev phpunit" or "ddev phpunit web/modules/custom/server_general".
 
+set -euo pipefail
+
 # Function to check if path contains sequential group tests
 needs_sequential() {
     local path="$1"


### PR DESCRIPTION
See example where tests would pass, if there's no `set -e` present

https://github.com/amitaibu/Microsites-Drupal-Starter/pull/8/commits/89d3e95ae4d6235d94929b8a2f12fe03cea7eb11