### PR TITLE
Accept self-signed certificates in the local Selenium container.

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSelenium2TestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSelenium2TestBase.php
@@ -33,7 +33,7 @@ class ServerGeneralSelenium2TestBase extends ExistingSiteSelenium2DriverTestBase
         // Accept self-signed certificates in the local Selenium container.
         // So calling https://drupal-starter.ddev.site:4443/
         // wouldn't result in certificate errors.
-        'acceptInsecureCerts' => TRUE,        
+        'acceptInsecureCerts' => TRUE,
         'goog:chromeOptions' => [
           'args' => [
             '--disable-dev-shm-usage',


### PR DESCRIPTION
Like that we can run tests calling `https://drupal-starter.ddev.site:4443/` or `https://additional-hostname.drupal-starter.ddev.site:4443/` from inside Selenium tests.

Extracted from here https://github.com/amitaibu/Microsites-Drupal-Starter/pull/7/files#diff-a14cbc0ab1ab4fa97efcdc956850a971da7289f2f4143740cbdfb5f916045279R36