### PR TITLE
More deploy ignores

### DIFF
--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -87,7 +87,10 @@ trait DeploymentTrait {
     'package-lock.json',
     'web/libraries/font-awesome/js-packages',
     'web/libraries/font-awesome/metadata',
+    'web/libraries/select2/src',
     'recipes',
+    'yarn.lock',
+    'patches.txt',
   ];
 
   /**


### PR DESCRIPTION
This is to eliminate false positives for security scans, `yarn.lock` does not represent what Drupal core has user-facing, those are DEV dependencies.