### PR TITLE
Migrate DDEV theme-watch command from PostCSS to Tailwind CLI

### DIFF
--- a/.ddev/commands/web/theme-watch
+++ b/.ddev/commands/web/theme-watch
@@ -5,4 +5,4 @@
 ## Aliases: theme-watch
 ## Example: "ddev theme:watch"
 
-cd ./web/themes/custom/server_theme && npx postcss ./src/pcss/style.pcss --output=./dist/css/style.css --watch --verbose
+cd ./web/themes/custom/server_theme && npx tailwindcss -i ./src/css/style.css -o ./dist/css/style.css --watch


### PR DESCRIPTION
After migrating to Tailwind v4, PostCSS is no longer used for CSS compilation. This PR updates the `theme-watch` command to use Tailwind CLI instead.