### PR TITLE
Fix XSS risk in QuoteThemeTrait

### DIFF
--- a/web/modules/custom/server_general/src/ThemeTrait/QuoteThemeTrait.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/QuoteThemeTrait.php
@@ -47,7 +47,7 @@ trait QuoteThemeTrait {
     // The photo credit on top of the image.
     $credit = [];
     if (!empty($image_credit)) {
-      $credit[] = ['#markup' => '© ' . $image_credit];
+      $credit[] = ['#plain_text' => '© ' . $image_credit];
     }
 
     return [


### PR DESCRIPTION
## Summary
- Use `#plain_text` instead of `#markup` for image credit field value in QuoteThemeTrait
- Prevents stored XSS via unsanitized `field_media_credit` content

## Test plan
- [ ] Verify quote paragraphs still render image credit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)