### PR TITLE
Handle API failures gracefully in release notes

### DIFF
--- a/robo-components/ReleaseNotesTrait.php
+++ b/robo-components/ReleaseNotesTrait.php
@@ -119,8 +119,13 @@ trait ReleaseNotesTrait {
       $pr_number = $pr_matches[1][0];
 
       if (!empty($github_org) && !empty($github_project)) {
-        /** @var \stdClass $pr_details */
-        $pr_details = $this->githubApiGet("repos/$github_org/$github_project/pulls/$pr_number");
+        try {
+          /** @var \stdClass $pr_details */
+          $pr_details = $this->githubApiGet("repos/$github_org/$github_project/pulls/$pr_number");
+        }
+        catch (\Exception $exception) {
+          $pr_details = NULL;
+        }
         if (!empty($pr_details->user)) {
           $contributors[] = '@' . $pr_details->user->login;
           $additions += $pr_details->additions;


### PR DESCRIPTION
## Summary
- Wrap GitHub API calls for PR details in try-catch to prevent exceptions from wrong PR/issue numbers from blocking entire release note generation
- Previously, any invalid PR number referenced in a commit message would throw an exception and prevent generating the release notes

## Testing
- Verify release notes can be generated even with commits containing invalid issue/PR references

🦺 Generated with [Opencode](https://github.com/anomalyco/opencode)