### PR TITLE
Move chdir to finally block

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -67,11 +67,13 @@ class RoboFile extends Tasks {
       $request = Request::createFromGlobals();
       $kernel = DrupalKernel::createFromRequest($request, $GLOBALS['drupal_autoloader'], 'prod');
       $kernel->handle($request);
-      chdir(__DIR__);
     }
     catch (\Exception $e) {
       // Do not fail, there are several commands that do not need Drupal.
       $this->yell($e->getMessage());
+    }
+    finally {
+      chdir(__DIR__);
     }
   }
 


### PR DESCRIPTION
If Drupal bootstrapping threw an exception, the working directory would remain wherever Drupal had changed it, rather than being restored to the project root.

By moving chdir(__DIR__) into a finally block, the working directory is now guaranteed to be reset to the project root regardless of whether bootstrapping succeeds or fails. This matters because subsequent Robo commands rely on the CWD being the project root.