### PR TITLE
Pin QA deploy checkout to workflow_run head_sha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
       DEPLOY_EXCLUDE_WARNING: ${{ vars.DEPLOY_EXCLUDE_WARNING }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary
- The `deploy-qa` job is triggered via `workflow_run`. Without an explicit `ref`, `actions/checkout@v4` checks out the latest commit on the branch, which may not be the commit whose CI actually succeeded.
- Pin the checkout to `github.event.workflow_run.head_sha` so the deployed code matches the tested code.

## Test plan
- [ ] Push a commit to `main`, observe the QA deploy job checks out the matching SHA.
- [ ] Land a follow-up commit before QA finishes; confirm QA still deploys the originally tested commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)