### PR TITLE
Add support for manual deployment steps per release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Sync Pantheon
         run: ddev robo deploy:pantheon-sync
 
+      - name: Run manual steps
+        run: ./ci-scripts/manual_step.sh test
+
   deploy-live:
     name: "Deploy to Pantheon LIVE"
     runs-on: ubuntu-latest
@@ -168,3 +171,6 @@ jobs:
 
       - name: Sync Pantheon LIVE
         run: ddev robo deploy:pantheon-sync live
+
+      - name: Run manual steps
+        run: ./ci-scripts/manual_step.sh live

--- a/README.md
+++ b/README.md
@@ -392,6 +392,24 @@ After you have automatic deployment for a project, you are able to deploy to Pan
 `git tag 0.1.2` will imply a deployment to the `test` environment (and `dev` - as enforced by Pantheon).
 `git tag 0.1.2_live` will imply a deployment to `live`. In order to make it fast, you need to first create the tag that deploy to `test`, then you need to tag the same commit with a tag suffixed with `_live`.
 
+### Manual Steps
+
+For certain releases, you may need to execute manual scripts after deployment. Place release-specific scripts in the `manual_steps/` directory with the version as the filename (e.g., `manual_steps/2.10.0.sh`).
+
+The script receives the environment as a parameter (`test` or `live`):
+
+```bash
+#!/bin/bash
+set -e
+
+ENV="${1:-TEST}"
+
+# Example: Clear cache after deployment
+ddev . terminus remote:drush "drupal-starter-site.$ENV" -- cr
+```
+
+When deploying a tag (e.g., `2.10.0` or `2.10.0_live`), the script `manual_steps/2.10.0.sh` will be called automatically after the sync. If no script exists for the version, deployment continues normally.
+
 ### Excluding Warnings in Deployment
 
 During deployment, Drupal status page warnings are [posted](https://github.com/Gizra/drupal-starter/blob/958cacc357e55b9bdf99d287cba69043236c673f/robo-components/DeploymentTrait.php#L449C19-L449C47) to GitHub as a comment. However, there might be some warnings

--- a/ci-scripts/manual_step.sh
+++ b/ci-scripts/manual_step.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+ENV="${1:-TEST}"
+
+VERSION="${GITHUB_REF_NAME%_live}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../manual_steps/${VERSION}.sh"
+
+if [ -f "$SCRIPT_DIR" ]; then
+  echo "Running manual steps for $VERSION on $ENV..."
+  bash "$SCRIPT_DIR" "$ENV"
+else
+  echo "No manual steps found for $VERSION, skipping..."
+fi

--- a/manual_steps/2.10.0.sh
+++ b/manual_steps/2.10.0.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+ENV="${1:-TEST}"
+
+ddev . terminus remote:drush "drupal-starter-site.$ENV" -- cr


### PR DESCRIPTION
## Summary
- Implement support for running manual scripts after deployment based on the git tag version
- Add `ci-scripts/manual_step.sh` that looks for version-specific scripts in `manual_steps/` directory
- Add example script `manual_steps/2.10.0.sh` that clears cache after deployment
- Update deploy workflow to run manual steps after sync in both test and live environments
- Add documentation in README.md

This feature allows teams to execute custom scripts for specific releases without modifying the main deployment workflow.

🦺 Generated with [Opencode](https://github.com/anomalyco/opencode)