### PR TITLE
New widget to access paragraph_edit routes directly from the edit form

### DIFF
--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -11,8 +11,8 @@ dependencies:
   module:
     - content_moderation
     - metatag
-    - paragraphs
     - path
+    - server_general
 id: node.landing_page.default
 targetEntityType: node
 bundle: landing_page
@@ -40,7 +40,7 @@ content:
       use_details: true
     third_party_settings: {  }
   field_paragraphs:
-    type: paragraphs
+    type: paragraphs_edit
     weight: 10
     region: content
     settings:

--- a/web/modules/custom/server_general/src/Plugin/Field/FieldWidget/ParagraphsEditWidget.php
+++ b/web/modules/custom/server_general/src/Plugin/Field/FieldWidget/ParagraphsEditWidget.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\paragraphs\Plugin\Field\FieldWidget\ParagraphsWidget;
+
+/**
+ * Plugin implementation of the 'paragraphs_edit' paragraphs widget.
+ *
+ * Extends the core ParagraphsWidget to add an "Edit standalone" button
+ * that opens the paragraph edit form in a separate page.
+ *
+ * @FieldWidget(
+ *   id = "paragraphs_edit",
+ *   label = @Translation("Paragraphs (edit in new tab)"),
+ *   description = @Translation("Paragraphs widget with edit in new tab option."),
+ *   field_types = {
+ *     "entity_reference_revisions"
+ *   }
+ * )
+ */
+#[FieldWidget(
+  id: 'paragraphs_edit',
+  label: new TranslatableMarkup('Paragraphs (edit in new tab)'),
+  description: new TranslatableMarkup('Paragraphs widget with edit in new tab option.'),
+  field_types: ['entity_reference_revisions']
+)]
+class ParagraphsEditWidget extends ParagraphsWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    $field_name = $this->fieldDefinition->getName();
+    $parents = $element['#field_parents'];
+
+    $widget_state = static::getWidgetState($parents, $field_name, $form_state);
+
+    if (!isset($widget_state['paragraphs'][$delta])) {
+      return $element;
+    }
+
+    $paragraphs_entity = $widget_state['paragraphs'][$delta]['entity'] ?? NULL;
+    if (!$paragraphs_entity) {
+      return $element;
+    }
+
+    $host = $items->getEntity();
+    $item_mode = $widget_state['paragraphs'][$delta]['mode'] ?? 'edit';
+
+    if ($item_mode === 'closed' || $item_mode === 'convert') {
+      $edit_new_tab_url = Url::fromRoute('paragraphs_edit.edit_form', [
+        'root_parent_type' => $host->getEntityTypeId(),
+        'root_parent' => $host->id(),
+        'paragraph' => $paragraphs_entity->id(),
+      ]);
+
+      $edit_new_tab_url->setOption('query', [
+        'destination' => \Drupal::request()->getRequestUri(),
+      ]);
+
+      if (!isset($element['top']['actions']['dropdown_actions'])) {
+        $element['top']['actions']['dropdown_actions'] = [];
+      }
+
+      $element['top']['actions']['dropdown_actions']['edit_new_tab_button'] = [
+        '#type' => 'link',
+        '#title' => $this->t('Edit standalone'),
+        '#url' => $edit_new_tab_url,
+        '#attributes' => [
+          'class' => ['button', 'button--small', 'paragraphs-dropdown-action'],
+        ],
+        '#access' => $paragraphs_entity->access('update'),
+        '#weight' => 0,
+      ];
+    }
+
+    return $element;
+  }
+
+}

--- a/web/modules/custom/server_general/src/Plugin/Field/FieldWidget/ParagraphsEditWidget.php
+++ b/web/modules/custom/server_general/src/Plugin/Field/FieldWidget/ParagraphsEditWidget.php
@@ -14,8 +14,8 @@ use Drupal\paragraphs\Plugin\Field\FieldWidget\ParagraphsWidget;
 /**
  * Plugin implementation of the 'paragraphs_edit' paragraphs widget.
  *
- * Extends the core ParagraphsWidget to add an "Edit standalone" button
- * that opens the paragraph edit form in a separate page.
+ * Extends the core ParagraphsWidget to swap the main Edit button with
+ * a link to the standalone edit page, and moves inline editing to dropdown.
  *
  * @FieldWidget(
  *   id = "paragraphs_edit",
@@ -57,14 +57,14 @@ class ParagraphsEditWidget extends ParagraphsWidget {
     $host = $items->getEntity();
     $item_mode = $widget_state['paragraphs'][$delta]['mode'] ?? 'edit';
 
-    if ($item_mode === 'closed' || $item_mode === 'convert') {
-      $edit_new_tab_url = Url::fromRoute('paragraphs_edit.edit_form', [
+    if ($item_mode === 'closed') {
+      $edit_standalone_url = Url::fromRoute('paragraphs_edit.edit_form', [
         'root_parent_type' => $host->getEntityTypeId(),
         'root_parent' => $host->id(),
         'paragraph' => $paragraphs_entity->id(),
       ]);
 
-      $edit_new_tab_url->setOption('query', [
+      $edit_standalone_url->setOption('query', [
         'destination' => \Drupal::request()->getRequestUri(),
       ]);
 
@@ -72,15 +72,22 @@ class ParagraphsEditWidget extends ParagraphsWidget {
         $element['top']['actions']['dropdown_actions'] = [];
       }
 
-      $element['top']['actions']['dropdown_actions']['edit_new_tab_button'] = [
+      if (isset($element['top']['actions']['actions']['edit_button'])) {
+        $edit_button = $element['top']['actions']['actions']['edit_button'];
+        unset($element['top']['actions']['actions']['edit_button']);
+
+        $edit_button['#value'] = $this->t('Edit inline');
+        $element['top']['actions']['dropdown_actions']['edit_inline_button'] = $edit_button;
+      }
+
+      $element['top']['actions']['actions']['edit_button'] = [
         '#type' => 'link',
-        '#title' => $this->t('Edit standalone'),
-        '#url' => $edit_new_tab_url,
+        '#title' => $this->t('Edit'),
+        '#url' => $edit_standalone_url,
         '#attributes' => [
-          'class' => ['button', 'button--small', 'paragraphs-dropdown-action'],
+          'class' => ['button', 'button--small'],
         ],
         '#access' => $paragraphs_entity->access('update'),
-        '#weight' => 0,
       ];
     }
 


### PR DESCRIPTION
#783 

@amitaibu The creation part of this feature is quite complicated, I vote for adding a simple enhancement for now. Maybe combined with #1018 we won't need the creation part at all.

https://github.com/user-attachments/assets/f2de7fbf-60c6-40d1-8e48-e4dbbe37e25c

