### PR TITLE
Pre-compile Twig templates after Pantheon deploy

### DIFF
--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -507,6 +507,7 @@ trait DeploymentTrait {
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cim --no-interaction")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cim --no-interaction")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cr")
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- twig:compile")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- deploy:hook --no-interaction")
       ->run()
       ->getExitCode();

--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -507,6 +507,8 @@ trait DeploymentTrait {
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cim --no-interaction")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cim --no-interaction")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- cr")
+      // Pre-warm the Twig template cache so the first anonymous request
+      // after deploy gets a cached hit.
       ->exec("terminus remote:drush $pantheon_terminus_environment -- twig:compile")
       ->exec("terminus remote:drush $pantheon_terminus_environment -- deploy:hook --no-interaction")
       ->run()


### PR DESCRIPTION
## Summary
- Add `drush twig:compile` after the final `cr` in `deployPantheonSync` (between the second `cr` and `deploy:hook`), so the first request post-deploy doesn't pay the Twig compilation cost.

## Test plan
- [ ] QA deploy job logs show `terminus remote:drush ... -- twig:compile` running between the second `cr` and `deploy:hook --no-interaction`
- [ ] Overall deploy succeeds end-to-end (no `stopOnFail` abort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)