### PR TITLE
Stale update status cache causes false "not secure" warnings during Pantheon deploy checks

### DIFF
--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -588,6 +588,18 @@ trait DeploymentTrait {
   public function deployCheckRequirementErrors(string $environment): void {
     $pantheon_info = $this->getPantheonNameAndEnv();
     $pantheon_terminus_environment = $pantheon_info['name'] . '.' . $environment;
+
+    // Drush CLI calls have no Drupal route match, so
+    // UpdateManager::projectStorage() always returns its stale cached
+    // project data instead of recomputing it, which can produce false
+    // "Not secure!" warnings for the version we just deployed. Clear it
+    // before checking requirements, in its own stack so its output does
+    // not get mixed into the rq JSON response below.
+    $this->taskExecStack()
+      ->stopOnFail()
+      ->exec("terminus remote:drush $pantheon_terminus_environment -- php:eval \"\\Drupal::keyValueExpirable('update')->delete('update_project_projects');\"")
+      ->run();
+
     $task = $this->taskExecStack()
       ->stopOnFail();
     $output = $task


### PR DESCRIPTION
Closes #1058

## Summary
- `deployCheckRequirementErrors()` runs `drush rq` as the last step of a Pantheon deploy, but Drush CLI calls never match a Drupal route, so `UpdateManager::projectStorage()` always serves its stale cached `update_project_projects` data instead of recomputing it against the code just deployed.
- This can produce false "Not secure!" warnings for a module/core version that was in fact the one just deployed.
- Fix: clear the `update_project_projects` key in the `update` keyvalue-expirable store via `terminus remote:drush ... -- php:eval` in its own exec stack, immediately before the `rq` check, so the comparison is always computed fresh.

## Test plan

- [x] `ddev phpstan` — no errors
- [x] Verified the exact eval command locally with `ddev drush`: populated the `update_project_projects` key via `Drupal::service('update.manager')->getProjects()`, ran the delete command, confirmed the key was removed from `keyValueExpirable('update')`
- [ ] Not yet verified end-to-end against a live Pantheon deploy (requires terminus auth not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

TB: 0.7/1h