### PR TITLE
Fix extra whitespace in class attributes generated by Twig templates

### DIFF
--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRedundantSpacingTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRedundantSpacingTest.php
@@ -16,9 +16,33 @@ use Symfony\Component\HttpFoundation\Response;
  * over raw markup, so that quoting style, comments, and non-attribute text
  * don't produce false positives/negatives.
  *
+ * The check is scoped to an allow-list of root selectors that correspond to
+ * markup owned by this project (custom theme + custom modules), so that it
+ * doesn't flag markup provided by Drupal Core or contrib modules (e.g. the
+ * admin toolbar, contextual links, or the messages region) that we can't fix
+ * ourselves.
+ *
  * @group server_general
  */
 class ServerGeneralRedundantSpacingTest extends ServerGeneralTestBase {
+
+  /**
+   * Root selectors that scope the test to markup owned by this project.
+   *
+   * Each selector is checked both for its own class attribute and for the
+   * class attribute of every descendant element.
+   *
+   * @var string[]
+   */
+  private const SCANNED_ROOT_SELECTORS = [
+    // Style-guide component sandbox (everything rendered by
+    // StyleGuideController).
+    'dl.accordion',
+    // Main navigation menu (menu--main.html.twig), covers both the
+    // mobile <ul class="main-menu"> and desktop <div class="main-menu">
+    // variants.
+    '.main-menu',
+  ];
 
   /**
    * Tests that no class attribute contains redundant whitespace.
@@ -33,13 +57,25 @@ class ServerGeneralRedundantSpacingTest extends ServerGeneralTestBase {
     $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
 
     $html = (string) $this->getSession()->getPage()->getContent();
-
     $crawler = new Crawler($html);
-    $classValues = $crawler->filter('[class]')->extract(['class']);
+
+    $classValues = [];
+    foreach (self::SCANNED_ROOT_SELECTORS as $selector) {
+      // The root element's own class attribute.
+      $classValues = array_merge(
+        $classValues,
+        $crawler->filter($selector)->extract(['class'])
+      );
+      // The class attribute of every descendant element.
+      $classValues = array_merge(
+        $classValues,
+        $crawler->filter($selector . ' [class]')->extract(['class'])
+      );
+    }
 
     $this->assertNotEmpty(
       $classValues,
-      'No elements with a class attribute were found on /style-guide — check that the page rendered correctly.'
+      'No elements with a class attribute were found in the scanned regions (' . implode(', ', self::SCANNED_ROOT_SELECTORS) . ') on /style-guide — check that the page rendered correctly or that the selectors still match the markup.'
     );
 
     $offenders = [];

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRedundantSpacingTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRedundantSpacingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Checks that class attributes on the /style-guide have no redundant spaces.
+ *
+ * Checks that class attributes on the /style-guide page have no redundant
+ * leading, trailing, or repeated spaces. Uses the DOM crawler
+ * (proper HTML parsing) to extract class attribute values, rather than regex
+ * over raw markup, so that quoting style, comments, and non-attribute text
+ * don't produce false positives/negatives.
+ *
+ * @group server_general
+ */
+class ServerGeneralRedundantSpacingTest extends ServerGeneralTestBase {
+
+  /**
+   * Tests that no class attribute contains redundant whitespace.
+   */
+  public function testNoRedundantSpacesInClassAttributes(): void {
+    // Log in as admin to get access to the style-guide page.
+    $user = $this->createUser();
+    $user->addRole('administrator');
+    $user->save();
+    $this->drupalLogin($user);
+    $this->drupalGet('/style-guide');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+
+    $html = (string) $this->getSession()->getPage()->getContent();
+
+    $crawler = new Crawler($html);
+    $classValues = $crawler->filter('[class]')->extract(['class']);
+
+    $this->assertNotEmpty(
+      $classValues,
+      'No elements with a class attribute were found on /style-guide — check that the page rendered correctly.'
+    );
+
+    $offenders = [];
+    foreach ($classValues as $index => $classValue) {
+      // Leading space, trailing space, or 2+ consecutive spaces.
+      if (preg_match('/^\s|\s{2,}|\s$/', $classValue) === 1) {
+        $offenders[$index] = $classValue;
+      }
+    }
+
+    $this->assertEmpty(
+      $offenders,
+      sprintf(
+        "Found %d class attribute(s) with redundant spaces on /style-guide:\n%s",
+        count($offenders),
+        implode("\n", array_map(
+          static fn (string $v): string => '"' . $v . '"',
+          $offenders
+        ))
+      )
+    );
+  }
+
+}

--- a/web/themes/custom/server_theme/templates/menu--main.html.twig
+++ b/web/themes/custom/server_theme/templates/menu--main.html.twig
@@ -66,9 +66,9 @@
       <li{{ item.attributes.addClass(item_classes) }}>
         {% set item_tag = item.below ? "button" : "a" %}
         {% if menu_level == 0 %}
-          <{{ item_tag }} href="{{ item.url }}" class="menu-root-item pb-2 flex items-center text-xl md:text-2xl w-full text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }}{% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+          <{{ item_tag }} href="{{ item.url }}" class="menu-root-item pb-2 flex items-center text-xl md:text-2xl w-full text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }}{% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4{{ item.in_active_trail ? ' expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
         {% elseif menu_level == 1 %}
-          <{{ item_tag }} href="{{ item.url }}" class="menu-sub-item pb-2 flex items-center text-lg md:text-xl text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+          <{{ item_tag }} href="{{ item.url }}" class="menu-sub-item pb-2 flex items-center text-lg md:text-xl text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4{{ item.in_active_trail ? ' expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
         {% else %}
           <{{ item_tag }} href="{{ item.url }}" class="menu-sub-item pb-2 block{{ item.in_active_trail ? ' active' }}">{{ item.title }}</{{ item_tag }}>
         {% endif %}
@@ -158,9 +158,9 @@ We call a macro which calls itself to render the full tree.
             <li{{ item.attributes.setAttributes('class', item_classes) }}>
               {% set item_tag = item.below ? "button" : "a" %}
               {% if menu_starting_level == 0 %}
-                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-root-item flex items-center base leading-11 lg:text-xl font-header pb-2 w-full text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-root-item flex items-center base leading-11 lg:text-xl font-header pb-2 w-full text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4{{ item.in_active_trail ? ' expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
               {% elseif menu_starting_level == 1 %}
-                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-sub-item flex items-center pb-2 text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-sub-item flex items-center pb-2 text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4{{ item.in_active_trail ? ' expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
               {% else %}
                 <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-sub-item pb-2 block{{ item.in_active_trail ? ' active' }}">{{ item.title }}</{{ item_tag }}>
               {% endif %}

--- a/web/themes/custom/server_theme/templates/menu--main.html.twig
+++ b/web/themes/custom/server_theme/templates/menu--main.html.twig
@@ -66,11 +66,11 @@
       <li{{ item.attributes.addClass(item_classes) }}>
         {% set item_tag = item.below ? "button" : "a" %}
         {% if menu_level == 0 %}
-          <{{ item_tag }} href="{{ item.url }}" class="menu-root-item pb-2 flex items-center text-xl md:text-2xl w-full text-left {{ item.in_active_trail ? 'active' }}">{{ item.title }}{% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+          <{{ item_tag }} href="{{ item.url }}" class="menu-root-item pb-2 flex items-center text-xl md:text-2xl w-full text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }}{% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
         {% elseif menu_level == 1 %}
-          <{{ item_tag }} href="{{ item.url }}" class="menu-sub-item pb-2 flex items-center text-lg md:text-xl text-left {{ item.in_active_trail ? 'active' }}">{{ item.title }} {% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+          <{{ item_tag }} href="{{ item.url }}" class="menu-sub-item pb-2 flex items-center text-lg md:text-xl text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %} <span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
         {% else %}
-          <{{ item_tag }} href="{{ item.url }}" class="menu-sub-item pb-2 block {{ item.in_active_trail ? 'active' }}">{{ item.title }}</{{ item_tag }}>
+          <{{ item_tag }} href="{{ item.url }}" class="menu-sub-item pb-2 block{{ item.in_active_trail ? ' active' }}">{{ item.title }}</{{ item_tag }}>
         {% endif %}
         {#
          Loops recursively to create all lower levels of the menu structure.
@@ -158,11 +158,11 @@ We call a macro which calls itself to render the full tree.
             <li{{ item.attributes.setAttributes('class', item_classes) }}>
               {% set item_tag = item.below ? "button" : "a" %}
               {% if menu_starting_level == 0 %}
-                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-root-item flex items-center base leading-11 lg:text-xl font-header pb-2 w-full text-left {{ item.in_active_trail ? 'active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-root-item flex items-center base leading-11 lg:text-xl font-header pb-2 w-full text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
               {% elseif menu_starting_level == 1 %}
-                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-sub-item flex items-center pb-2 text-left {{ item.in_active_trail ? 'active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
+                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-sub-item flex items-center pb-2 text-left{{ item.in_active_trail ? ' active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>
               {% else %}
-                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-sub-item pb-2 block {{ item.in_active_trail ? 'active' }}">{{ item.title }}</{{ item_tag }}>
+                <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-sub-item pb-2 block{{ item.in_active_trail ? ' active' }}">{{ item.title }}</{{ item_tag }}>
               {% endif %}
               {#
               Loops recursively to create all lower levels of the menu structure.

--- a/web/themes/custom/server_theme/templates/server-theme-bg-color-base.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-bg-color-base.html.twig
@@ -1,9 +1,4 @@
 {# Get the TW background color. #}
 {% macro getBgColor(color) %}
-  {% if color == 'light-gray' %}
-    bg-gray-100
-  {% else %}
-    bg-transparent
-  {% endif %}
+  {{- color == 'light-gray' ? 'bg-gray-100' : 'bg-transparent' -}}
 {% endmacro %}
-

--- a/web/themes/custom/server_theme/templates/server-theme-button.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-button.html.twig
@@ -7,7 +7,7 @@
   actual_button_type == 'primary' ? 'bg-blue-500 text-white hover:bg-white hover:text-blue-500 focus-visible:bg-white focus-visible:text-blue-500',
   actual_button_type == 'secondary' ? 'text-blue-900 bg-white border-blue-900 hover:text-white hover:bg-blue-900 focus-visible:text-white focus-visible:bg-blue-900',
   actual_button_type == 'tertiary' ? 'text-white bg-emerald-900 border-emerald-900 hover:text-emerald-900 hover:bg-white focus-visible:text-emerald-900 focus-visible:bg-white',
-] | join(' ') | trim %}
+] | filter(v => v) | join(' ') %}
 
 {% set target = open_new_tab ? '_blank' : '_self' %}
 

--- a/web/themes/custom/server_theme/templates/server-theme-container-max-width.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-max-width.html.twig
@@ -1,13 +1,21 @@
-{% if width == 'lg' %}
-  {% set size_classes = 'max-w-lg' %}
-{% elseif width == 'xl' %}
-  {% set size_classes = 'max-w-xl' %}
-{% elseif width == '2xl' %}
-  {% set size_classes = 'max-w-2xl' %}
-{% elseif width == '3xl' %}
-  {% set size_classes = 'max-w-3xl' %}
-{% endif %}
+{#
+Maps the `width` prop to a Tailwind max-width class.
+Any value not listed here (including empty/undefined) silently
+falls back to '' — no width constraint is applied, and no error
+is thrown. See `default('')` below.
+#}
+{% set size_map = {
+  'lg': 'max-w-lg',
+  'xl': 'max-w-xl',
+  '2xl': 'max-w-2xl',
+  '3xl': 'max-w-3xl',
+} %}
 
-<div class="{{ size_classes }} {{ is_center ? 'mx-auto' }}">
+{% set classes = [
+  size_map[width] | default(''),
+  is_center ? 'mx-auto',
+] | filter(v => v) | join(' ') %}
+
+<div class="{{ classes }}">
   {{ element }}
 </div>

--- a/web/themes/custom/server_theme/templates/server-theme-container-narrow.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-narrow.html.twig
@@ -1,15 +1,14 @@
 {% import '@server_theme/templates/server-theme-bg-color-base.html.twig' as bgColorBase %}
 
-{% set color_class = bgColorBase.getBgColor(bg_color) %}
+{% set color_class = bgColorBase.getBgColor(bg_color)|trim %}
+{% set py_class = color_class != 'bg-transparent' ? 'py-8 md:py-10' : '' %}
+{% set classes = [color_class, py_class]|filter(v => v)|join(' ') %}
 
-{% if color_class|trim != 'bg-transparent' %}
-  {% set py_class = 'py-8 md:py-10' %}
-{% endif %}
-
-<div class="{{ color_class }} {{ py_class }}">
+<div class="{{ classes }}">
   <div class="container-narrow w-full">
     {{ element }}
   </div>
 </div>
+
 
 

--- a/web/themes/custom/server_theme/templates/server-theme-container-narrow.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-narrow.html.twig
@@ -9,6 +9,3 @@
     {{ element }}
   </div>
 </div>
-
-
-

--- a/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-big.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-big.html.twig
@@ -1,12 +1,12 @@
 {% macro getClass(align) %}
-  {% set classes = [
+  {%- set classes = [
     'flex flex-col gap-y-8 md:gap-y-10',
     align == 'stretch' ? 'items-stretch',
     align == 'start' ? 'items-start',
     align == 'center' ? 'items-center',
     align == 'end' ? 'items-end',
-  ] | join(' ') | trim %}
-  {{ classes }}
+  ] | filter(v => v) | join(' ') %}
+  {{- classes -}}
 {% endmacro %}
 <div class="{{ _self.getClass(align) }}">
   {{ items }}

--- a/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-huge.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-huge.html.twig
@@ -1,12 +1,12 @@
 {% macro getClass(align) %}
-  {% set classes = [
+  {%- set classes = [
     'flex flex-col gap-y-12 md:gap-y-15',
     align == 'stretch' ? 'items-stretch',
     align == 'start' ? 'items-start',
     align == 'center' ? 'items-center',
     align == 'end' ? 'items-end',
-  ] | join(' ') | trim %}
-  {{ classes }}
+  ] | filter(v => v) | join(' ') %}
+  {{- classes -}}
 {% endmacro %}
 <div class="{{ _self.getClass(align) }}">
   {{ items }}

--- a/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-tiny.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing-tiny.html.twig
@@ -1,13 +1,14 @@
 {% macro getClass(align) %}
-  {% set classes = [
+  {%- set classes = [
     'flex flex-col gap-y-2',
     align == 'stretch' ? 'items-stretch',
     align == 'start' ? 'items-start',
     align == 'center' ? 'items-center',
     align == 'end' ? 'items-end',
-  ] | join(' ') | trim %}
-  {{ classes }}
+  ] | filter(v => v) | join(' ') %}
+  {{- classes -}}
 {% endmacro %}
 <div class="{{ _self.getClass(align) }}">
   {{ items }}
 </div>
+

--- a/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-vertical-spacing.html.twig
@@ -1,12 +1,12 @@
 {% macro getClass(align) %}
-  {% set classes = [
+  {%- set classes = [
     'flex flex-col gap-3 md:gap-5',
     align == 'stretch' ? 'items-stretch',
     align == 'start' ? 'items-start',
     align == 'center' ? 'items-center',
     align == 'end' ? 'items-end',
-  ] | join(' ') | trim %}
-  {{ classes }}
+  ] | filter(v => v) | join(' ') %}
+  {{- classes -}}
 {% endmacro %}
 <div class="{{ _self.getClass(align) }}">
   {{ items }}

--- a/web/themes/custom/server_theme/templates/server-theme-container-wide.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-container-wide.html.twig
@@ -1,13 +1,12 @@
 {% import '@server_theme/templates/server-theme-bg-color-base.html.twig' as bgColorBase %}
 
-{% set color_class = bgColorBase.getBgColor(bg_color) %}
+{% set color_class = bgColorBase.getBgColor(bg_color)|trim %}
+{% set py_class = color_class != 'bg-transparent' ? 'py-8 md:py-10' : '' %}
+{% set classes = [color_class, py_class]|filter(v => v)|join(' ') %}
 
-{% if color_class|trim != 'bg-transparent' %}
-  {% set py_class = 'py-8 md:py-10' %}
-{% endif %}
-
-<div class="{{ color_class }} {{ py_class }}">
+<div class="{{ classes }}">
   <div class="container-wide w-full">
     {{ element }}
   </div>
 </div>
+

--- a/web/themes/custom/server_theme/templates/server-theme-inner-element-layout-base.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-inner-element-layout-base.html.twig
@@ -1,5 +1,5 @@
 {# Base classes for the cards. #}
 {% macro getBaseClasses() %}
-  relative rounded-lg border border-gray-300 w-full h-full overflow-hidden
+  {{- 'relative rounded-lg border border-gray-300 w-full h-full overflow-hidden' -}}
 {% endmacro %}
 

--- a/web/themes/custom/server_theme/templates/server-theme-line-separator.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-line-separator.html.twig
@@ -1,1 +1,1 @@
-<div class="border-t border-wmo-blue-gray-600 "></div>
+<div class="border-t border-wmo-blue-gray-600"></div>

--- a/web/themes/custom/server_theme/templates/server-theme-text-decoration--link.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-text-decoration--link.html.twig
@@ -11,7 +11,7 @@
   hover_color_class,
   underline == 'always' ? 'underline',
   underline == 'hover' ? 'hover:underline',
-] | join(' ') | trim %}
+] | filter(v => v) | join(' ') %}
 
 <div class="{{ classes }}">
   {{ element }}

--- a/web/themes/custom/server_theme/templates/server-theme-text-decorations.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-text-decorations.html.twig
@@ -10,7 +10,7 @@
   is_bold ? 'font-bold',
   is_underline ? 'underline',
   font_size_class,
-] | join(' ') | trim %}
+] | filter(v => v) | join(' ') %}
 
 <div class="{{ classes }}">
   {{ element }}


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/9e8ae628-4490-44fb-938c-e625f773080e

After

https://github.com/user-attachments/assets/982b4288-5920-4d7d-adba-340ce5546ab1

## Description

Several Twig templates generate `class` attributes with extra whitespace: leading spaces, multiple consecutive spaces, and/or trailing spaces.

This PR fixes the affected templates so that rendered `class` attributes contain only single spaces between class names, with no leading or trailing whitespace.

## Steps to Reproduce

1. Open the `/style-guide` page.
2. Open Chrome DevTools and switch to the **Console** tab.
3. Run the following script to scan the rendered HTML for `class` attributes with extra whitespace:

```js
fetch(location.href)
  .then(r => r.text())
  .then(html => {
    const pattern = /class="(?:\s[^"]*|[^"]*\s{2,}[^"]*|[^"]*\s)"/g;
    const matches = [...html.matchAll(pattern)].map(m => m[0]);
    console.table(matches);
    console.log('Class attributes with extra whitespace found:', matches.length);
  });
```

4. Observe that the script reports multiple matches — `class` attributes containing a leading space, multiple consecutive spaces, or a trailing space.

## Changes Made

Fixed 14 Twig templates across the theme that generated class attributes with leading, trailing, or duplicate whitespace. See the "Files changed" tab for the full list.

Added a PHPUnit test that renders the /style-guide page and fails if any class attribute contains leading, trailing, or duplicate whitespace.

## How to Verify

1. Open `/style-guide` after this change.
2. Re-run the script above in the console.
3. Confirm `Matches found: 0`.

## Checklist

- [ ] Verified with the console script above that no `class` attributes with extra whitespace remain on `/style-guide`
- [ ] Visually checked affected components to confirm no styling regressions
