### PR TITLE
Fix undefined method setAttributes() in menu--main.html.twig

### DIFF
--- a/web/themes/custom/server_theme/templates/menu--main.html.twig
+++ b/web/themes/custom/server_theme/templates/menu--main.html.twig
@@ -155,7 +155,7 @@ We call a macro which calls itself to render the full tree.
               menu_starting_level != 0 ? 'my-2.5 px-2.5 lg:my-0 lg:px-0',
             ] %}
 
-            <li{{ item.attributes.setAttributes('class', item_classes) }}>
+            <li{{ item.attributes.addClass(item_classes) }}>
               {% set item_tag = item.below ? "button" : "a" %}
               {% if menu_starting_level == 0 %}
                 <{{ item_tag }} data-menu-child="{{ item.below ? key|split(':')|last : '' }}" href="{{ item.url }}" class="menu-root-item flex items-center base leading-11 lg:text-xl font-header pb-2 w-full text-left {{ item.in_active_trail ? 'active' }}">{{ item.title }} {% if item.below %}<span class="expand-indicator flex justify-center items-center w-6 h-6 border-1 rounded-full border-white ml-4 {{ item.in_active_trail ? 'expand-indicator--expanded' }}"></span>{% endif %}</{{ item_tag }}>


### PR DESCRIPTION
**What**
Replaces the non-existent `Attribute::setAttributes()` call with `Attribute::addClass()` in the `menu_links_desktop` macro of `menu--main.html.twig`.

```diff
- <li{{ item.attributes.setAttributes('class', item_classes) }}>
+ <li{{ item.attributes.addClass(item_classes) }}>
```

**Why `addClass()` and not `setAttribute('class', ...)`**
`addClass()` appends to any classes already present on `item.attributes`, whereas `setAttribute('class', ...)` would overwrite the whole attribute, wiping out anything set by other code paths.

This also brings `menu_links_desktop` in line with the mobile macro `menu_links`, which already uses `addClass()` correctly for the same purpose — the two macros are now consistent.