### PR TITLE
#940 Show Selenium tests in noVNC again

### DIFF
--- a/.ddev/docker-compose.selenium-chrome_screen.yaml
+++ b/.ddev/docker-compose.selenium-chrome_screen.yaml
@@ -1,0 +1,9 @@
+services:
+  selenium-chrome:
+    environment:
+      # The virtual display has to be at least as large as the window the
+      # Selenium tests resize to, otherwise the browser is cut off over noVNC
+      # and in screenshots.
+      # @see \Drupal\Tests\server_general\TestConfiguration::BROWSER_WIDTH
+      - SCREEN_WIDTH=1920
+      - SCREEN_HEIGHT=1920

--- a/.ddev/docker-compose.selenium-chrome_screen.yaml
+++ b/.ddev/docker-compose.selenium-chrome_screen.yaml
@@ -1,9 +1,5 @@
 services:
   selenium-chrome:
     environment:
-      # The virtual display has to be at least as large as the window the
-      # Selenium tests resize to, otherwise the browser is cut off over noVNC
-      # and in screenshots.
-      # @see \Drupal\Tests\server_general\TestConfiguration::BROWSER_WIDTH
       - SCREEN_WIDTH=1920
       - SCREEN_HEIGHT=1920

--- a/README.md
+++ b/README.md
@@ -229,8 +229,10 @@ When it is hard to understand a test failure, a peek into the browser might help
 For Selenium-based ones, you can take screenshots using the `takeScreenshot()` method. This captures and saves
 the screenshot in `/web/sites/simpletest/screenshots`.
 You can also watch what the tests are doing in the browser using noVNC. To do so, simply open a browser and open
-https://drupal-starter.ddev.site:7900 and click Connect. The password is `secret`. Now simply run the tests
+https://drupal-starter.ddev.site:7900 and click Connect. No password is needed. Now simply run the tests
 and you can see the test running in the browser.
+
+Chrome only runs headless on CI, so locally there is always something to watch.
 
 For faster, virtual browser-based tests, you can use `createHtmlSnapshot` and it will dump the HTML content
 of the virtual browser into the `phpunit_debug` directory. For the exact filename, refer to the output of

--- a/ci-scripts/global_config.yaml
+++ b/ci-scripts/global_config.yaml
@@ -1,6 +1,11 @@
 omit_containers: ["dba"]
 instrumentation_opt_in: false
 
+# The runner sets CI, but ddev does not pass it into the containers. The tests
+# read it to run Chrome headless and to skip screenshots.
+web_environment:
+  - CI=true
+
 # You can turn off usage of the dba (phpmyadmin) container and/or
 # ddev-ssh-agent containers with
 # omit_containers["dba", "ddev-ssh-agent"]

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSelenium2TestBase.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSelenium2TestBase.php
@@ -28,21 +28,27 @@ class ServerGeneralSelenium2TestBase extends ExistingSiteSelenium2DriverTestBase
       $hostname = getenv('DRUPAL_TEST_WEBDRIVER_HOSTNAME') ?: 'selenium-chrome';
       $port = getenv('DRUPAL_TEST_WEBDRIVER_PORT') ?: '4444';
 
+      $args = [
+        '--disable-dev-shm-usage',
+        '--disable-gpu',
+        '--dns-prefetch-disable',
+        '--no-sandbox',
+      ];
+
+      if (getenv('CI') === 'true') {
+        // Locally Chrome draws on the Selenium container's virtual display, so
+        // the test run can be watched over noVNC. On CI nobody is watching, and
+        // headless is faster.
+        $args[] = '--headless';
+      }
+
       $capabilities = [
         'browserName' => 'chrome',
         // Accept self-signed certificates in the local Selenium container.
         // So calling https://drupal-starter.ddev.site:4443/
         // wouldn't result in certificate errors.
         'acceptInsecureCerts' => TRUE,
-        'goog:chromeOptions' => [
-          'args' => [
-            '--disable-dev-shm-usage',
-            '--disable-gpu',
-            '--headless',
-            '--dns-prefetch-disable',
-            '--no-sandbox',
-          ],
-        ],
+        'goog:chromeOptions' => ['args' => $args],
       ];
 
       $url = "http://{$hostname}:{$port}";


### PR DESCRIPTION
Fixes #940

## Root cause

`ServerGeneralSelenium2TestBase::getDriverInstance()` builds its own Chrome capabilities and hardcodes `--headless`, so it ignores `DTT_MINK_DRIVER_ARGS`. Headless Chrome never draws on the Selenium container's virtual display, so noVNC showed an empty desktop.

Regression from #912, which reinstalled the addon fresh and restored the upstream `--headless` defaults, undoing c69a58d.

## Changes

- Chrome runs headless only on CI, so locally the run can be watched over noVNC.
- `ci-scripts/global_config.yaml` sets `CI=true` in `web_environment`. The runner sets `CI`, but ddev does not pass it into the containers, so `getenv('CI')` was never true there. This also repairs the screenshot guard in `takeScreenshot()`.
- New `.ddev/docker-compose.selenium-chrome_screen.yaml` enlarges the virtual display to 1920x1920, so the 1900x1900 window the tests ask for is not cut off. Separate file so the `#ddev-generated` addon files stay upgradable.
- README no longer mentions the `secret` password. The container runs with `VNC_NO_PASSWORD=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
