### PR TITLE
Add GEO-related items to the Go Live Checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,3 +640,6 @@ you need to make sure Drupal is aware of the real IP of the visitors.
 - [ ] Redirects
 - [ ] Ensure email sending (SMTP) works
 - [ ] Remove http auth for LIVE environment
+- [ ] Confirm dev/staging "don't index" setting has been removed (sitemap + robots meta)
+- [ ] Confirm robots.txt / CDN isn't blocking search and AI retrieval bots (GPTBot family, ClaudeBot family, PerplexityBot family)
+- [ ] Confirm preview-control meta tags (nosnippet, max-image-preview) aren't overly restrictive

--- a/README.md
+++ b/README.md
@@ -641,6 +641,6 @@ you need to make sure Drupal is aware of the real IP of the visitors.
 - [ ] Ensure email sending (SMTP) works
 - [ ] Remove http auth for LIVE environment
 - [ ] Confirm dev/staging "don't index" setting has been removed (sitemap + robots meta)
-- [ ] Decide whether robots.txt / CDN should allow or block search and AI retrieval bots (GPTBot family, ClaudeBot family, PerplexityBot family, Meta-ExternalAgent)
+- [ ] Decide whether robots.txt / CDN should allow or block search and AI retrieval bots (GPTBot family, ClaudeBot family, PerplexityBot family, Meta-ExternalAgent) — recommendation: allow
 - [ ] Confirm preview-control meta tags (nosnippet, max-image-preview) aren't overly restrictive
 - [ ] Confirm Google-Extended is disallowed in robots.txt (free Gemini/Vertex training opt-out, no effect on Search/AI Overviews)

--- a/README.md
+++ b/README.md
@@ -641,6 +641,6 @@ you need to make sure Drupal is aware of the real IP of the visitors.
 - [ ] Ensure email sending (SMTP) works
 - [ ] Remove http auth for LIVE environment
 - [ ] Confirm dev/staging "don't index" setting has been removed (sitemap + robots meta)
-- [ ] Confirm robots.txt / CDN isn't blocking search and AI retrieval bots (GPTBot family, ClaudeBot family, PerplexityBot family, Meta-ExternalAgent)
+- [ ] Decide whether robots.txt / CDN should allow or block search and AI retrieval bots (GPTBot family, ClaudeBot family, PerplexityBot family, Meta-ExternalAgent)
 - [ ] Confirm preview-control meta tags (nosnippet, max-image-preview) aren't overly restrictive
 - [ ] Confirm Google-Extended is disallowed in robots.txt (free Gemini/Vertex training opt-out, no effect on Search/AI Overviews)

--- a/README.md
+++ b/README.md
@@ -641,5 +641,6 @@ you need to make sure Drupal is aware of the real IP of the visitors.
 - [ ] Ensure email sending (SMTP) works
 - [ ] Remove http auth for LIVE environment
 - [ ] Confirm dev/staging "don't index" setting has been removed (sitemap + robots meta)
-- [ ] Confirm robots.txt / CDN isn't blocking search and AI retrieval bots (GPTBot family, ClaudeBot family, PerplexityBot family)
+- [ ] Confirm robots.txt / CDN isn't blocking search and AI retrieval bots (GPTBot family, ClaudeBot family, PerplexityBot family, Meta-ExternalAgent)
 - [ ] Confirm preview-control meta tags (nosnippet, max-image-preview) aren't overly restrictive
+- [ ] Confirm Google-Extended is disallowed in robots.txt (free Gemini/Vertex training opt-out, no effect on Search/AI Overviews)


### PR DESCRIPTION
## Summary
- Adds three items to the README's Go Live Checklist, surfaced during a GEO strategy review: confirming dev/staging "don't index" settings are removed, that robots.txt/CDN isn't blocking search & AI retrieval bots, and that preview-control meta tags aren't overly restrictive.
- These were previously unverified at launch time despite being easy to check and a common real-world launch mistake.

## Test plan
- [ ] Confirm the checklist renders correctly in README.md
- [ ] Confirm existing checklist items are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2RvxX1f3552tpWf1Zu7M2