### PR TITLE
Fix autoloader mismatch on deploy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
     },
     "config": {
         "sort-packages": true,
+        "autoloader-suffix": "DrupalStarter",
         "allow-plugins": {
             "composer/installers": true,
             "cweagans/composer-patches": true,

--- a/robo-components/DeploymentTrait.php
+++ b/robo-components/DeploymentTrait.php
@@ -312,8 +312,11 @@ trait DeploymentTrait {
 
     $rsync_exclude_string = '--exclude=' . implode(' --exclude=', self::$deploySyncExcludes);
 
-    // Copy all files and folders.
-    $result = $this->_exec("rsync -az -q --delete $rsync_exclude_string . $pantheon_directory")->getExitCode();
+    // Copy all files and folders. Use --checksum so files whose content
+    // changed but whose size did not (e.g. autoload_real.php when the
+    // Composer autoloader suffix changes) are not skipped by rsync's default
+    // size+mtime quick check, which would commit a mismatched autoloader.
+    $result = $this->_exec("rsync -az -c -q --delete $rsync_exclude_string . $pantheon_directory")->getExitCode();
     if ($result !== 0) {
       throw new \Exception('File sync failed');
     }


### PR DESCRIPTION
## Summary
- Add a fixed `autoloader-suffix` in `composer.json` to prevent Composer from generating a random suffix on each install, which caused file content changes without size changes.
- Add `--checksum` (`-c`) flag to the rsync command in `DeploymentTrait.php` so that files whose content changed but whose size stayed the same are properly synced to the Pantheon artifact repo.

## Test plan
- [ ] Verify `composer install` generates autoloader files with the `DrupalStarter` suffix
- [ ] Verify deployment to Pantheon correctly syncs autoloader files even when file sizes don't change

🤖 Generated with [Claude Code](https://claude.com/claude-code)