### PR TITLE
Take the News teaser and search label from the content type

### DIFF
--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
@@ -60,9 +60,7 @@ class NodeNews extends NodeViewBuilderAbstract {
    *   Render array.
    */
   public function buildFull(array $build, NodeInterface $entity) {
-    // The node's label.
-    $node_type = $this->entityTypeManager->getStorage('node_type')->load($entity->bundle());
-    $label = $node_type->label();
+    $label = $this->getNodeTypeLabel($entity);
 
     // The hero responsive image.
     $medias = $entity->get('field_featured_image')->referencedEntities();
@@ -103,6 +101,7 @@ class NodeNews extends NodeViewBuilderAbstract {
     $timestamp = $this->getFieldOrCreatedTimestamp($entity, 'field_publish_date');
 
     $element = $this->buildElementNewsTeaser(
+      $this->getNodeTypeLabel($entity),
       $image,
       $title,
       $url,
@@ -135,6 +134,7 @@ class NodeNews extends NodeViewBuilderAbstract {
     $timestamp = $this->getFieldOrCreatedTimestamp($entity, 'field_publish_date');
 
     $element = $this->buildElementNewsTeaserFeatured(
+      $this->getNodeTypeLabel($entity),
       $image,
       $title,
       $url,
@@ -160,7 +160,7 @@ class NodeNews extends NodeViewBuilderAbstract {
    */
   public function buildSearchIndex(array $build, NodeInterface $entity) {
     $element = $this->buildElementSearchResult(
-      $this->t('News'),
+      $this->getNodeTypeLabel($entity),
       $entity->label(),
       $entity->toUrl(),
       $this->buildProcessedText($entity, 'field_body'),
@@ -170,6 +170,24 @@ class NodeNews extends NodeViewBuilderAbstract {
     $build[] = $element;
 
     return $build;
+  }
+
+  /**
+   * Get the node type label, shown as the tag above the title.
+   *
+   * Taken from the content type rather than a hardcoded string, so the full
+   * node, the teasers and the search results always show the same wording.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The entity.
+   *
+   * @return string
+   *   The node type label.
+   */
+  protected function getNodeTypeLabel(NodeInterface $entity): string {
+    $node_type = $this->entityTypeManager->getStorage('node_type')->load($entity->bundle());
+
+    return (string) $node_type->label();
   }
 
 }

--- a/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
+++ b/web/modules/custom/server_general/src/Plugin/EntityViewBuilder/NodeNews.php
@@ -127,7 +127,7 @@ class NodeNews extends NodeViewBuilderAbstract {
    */
   public function buildFeatured(array $build, NodeInterface $entity) {
     $media = $this->getReferencedEntityFromField($entity, 'field_featured_image');
-    $image = $media instanceof MediaInterface ? $this->buildImageStyle($media, 'card', 'field_media_image') : NULL;
+    $image = $media instanceof MediaInterface ? $this->buildImageStyle($media, 'card', 'field_media_image') : [];
     $title = $entity->label();
     $url = $entity->toUrl();
     $summary = $this->buildProcessedText($entity, 'field_body');

--- a/web/modules/custom/server_general/src/ThemeTrait/NewsTeasersThemeTrait.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/NewsTeasersThemeTrait.php
@@ -49,6 +49,8 @@ trait NewsTeasersThemeTrait {
   /**
    * Build "News Teaser" element.
    *
+   * @param string $label
+   *   The label shown above the title, usually the content type label.
    * @param array $image
    *   The image render array.
    * @param string $title
@@ -63,11 +65,11 @@ trait NewsTeasersThemeTrait {
    * @return array
    *   Render array.
    */
-  protected function buildElementNewsTeaser(array $image, string $title, Url $url, array $summary, int $timestamp): array {
+  protected function buildElementNewsTeaser(string $label, array $image, string $title, Url $url, array $summary, int $timestamp): array {
     $elements = [];
 
     // Labels.
-    $element = $this->buildLabelsFromText([$this->t('News')]);
+    $element = $this->buildLabelsFromText([$label]);
     $elements[] = $this->wrapTextResponsiveFontSize($element, FontSizeEnum::Sm);
 
     // Date.
@@ -89,6 +91,8 @@ trait NewsTeasersThemeTrait {
   /**
    * Build "Featured News Teaser" element with image on the side.
    *
+   * @param string $label
+   *   The label shown above the title, usually the content type label.
    * @param array $image
    *   The image render array.
    * @param string $title
@@ -103,11 +107,11 @@ trait NewsTeasersThemeTrait {
    * @return array
    *   Render array.
    */
-  protected function buildElementNewsTeaserFeatured(array $image, string $title, Url $url, array $summary, int $timestamp): array {
+  protected function buildElementNewsTeaserFeatured(string $label, array $image, string $title, Url $url, array $summary, int $timestamp): array {
     $elements = [];
 
     // Labels.
-    $element = $this->buildLabelsFromText([$this->t('News')]);
+    $element = $this->buildLabelsFromText([$label]);
     $elements[] = $this->wrapTextResponsiveFontSize($element, FontSizeEnum::Sm);
 
     // Date.

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeNewsTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeNewsTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\server_general\ExistingSite;
 
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -65,6 +67,56 @@ class ServerGeneralNodeNewsTest extends ServerGeneralNodeTestBase {
       'The og:description meta tag contains the exact expected string.'
     );
 
+  }
+
+  /**
+   * Test the label above the title is taken from the content type.
+   */
+  public function testContentTypeLabel() {
+    $node = $this->createNode([
+      'title' => 'A node to check the label of',
+      'type' => 'news',
+      'field_body' => 'This is the text of the body field.',
+      'moderation_state' => 'published',
+    ]);
+
+    $node_type = NodeType::load('news');
+    $original_label = $node_type->label();
+    $label = 'Bulletin ' . $this->randomMachineName();
+
+    $node_type->set('name', $label)->save();
+
+    try {
+      foreach (['full', 'teaser', 'featured', 'search_index'] as $view_mode) {
+        $this->assertStringContainsString(
+          $label,
+          $this->renderNode($node, $view_mode),
+          "The $view_mode view mode shows the content type label."
+        );
+      }
+    }
+    finally {
+      $node_type->set('name', $original_label)->save();
+    }
+  }
+
+  /**
+   * Render a node in a given view mode.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to render.
+   * @param string $view_mode
+   *   The view mode.
+   *
+   * @return string
+   *   The rendered markup.
+   */
+  protected function renderNode(NodeInterface $node, string $view_mode): string {
+    $build = \Drupal::entityTypeManager()
+      ->getViewBuilder('node')
+      ->view($node, $view_mode);
+
+    return (string) \Drupal::service('renderer')->renderInIsolation($build);
   }
 
 }

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -464,6 +464,7 @@ class StyleGuideController extends ControllerBase {
     $timestamp = time();
 
     $card = $this->buildElementNewsTeaser(
+      'News',
       $image,
       $title,
       $url,
@@ -476,6 +477,7 @@ class StyleGuideController extends ControllerBase {
     $summary = $this->buildProcessedText('A much <strong>shorter</strong> intro');
 
     $card2 = $this->buildElementNewsTeaser(
+      'News',
       $image,
       $title,
       $url,
@@ -881,6 +883,7 @@ class StyleGuideController extends ControllerBase {
     for ($i = 0; $i < $num; $i++) {
       $elements[] = call_user_func(
         [$this, $func],
+        'News',
         $this->buildImage($this->getPlaceholderImage(300, 200, "card_image_$i", 'seed')),
         $this->getRandomTitle(),
         Url::fromRoute('<front>'),


### PR DESCRIPTION
`NodeNews::buildFull` renders the content type label, but the teaser cards, the featured teaser and the search result build theirs from a hardcoded `t('News')`. On a site that renames the News content type, or runs in a language where that string is translated, the two disagree — the full node shows the content type label while the cards still read "News". The label now comes from the content type in all four view modes; the style guide keeps passing a literal, like it already does for the search result.