### PR TITLE
Accessibility test cases for drupal-starter

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,51 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+env:
+  DDEV_NO_INSTRUMENTATION: true
+jobs:
+  accessibility:
+    name: "Accessibility: WCAG 2.2 AA"
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - name: Install DDEV
+        run: ./ci-scripts/install_ddev.sh
+
+      - name: Install Drupal
+        run: ./ci-scripts/install_drupal.sh
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install Playwright dependencies
+        working-directory: accessibility-testing
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        working-directory: accessibility-testing
+        run: npx playwright install --with-deps
+
+      - name: Run accessibility tests
+        working-directory: accessibility-testing
+        run: npx playwright test
+        env:
+          BASE_URL: http://drupal-starter.ddev.site:8880
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: accessibility-report
+          path: accessibility-testing/playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 env:
   DDEV_NO_INSTRUMENTATION: true
 jobs:
@@ -25,7 +25,7 @@ jobs:
       - name: Install Drupal
         run: ./ci-scripts/install_drupal.sh
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,11 @@ phpunit_debug
 # AI
 .claude
 CLAUDE.md
+
+# Playwright
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+playwright/.auth/

--- a/README.md
+++ b/README.md
@@ -259,6 +259,33 @@ To run PHPUnit tests for the `migrate_tools` contributed module, you would use:
 ddev phpunit-contrib migrate_tools
 ```
 
+### Accessibility Testing (WCAG 2.2 AA)
+
+Automated accessibility checks run via [Playwright](https://playwright.dev/) and
+[`@axe-core/playwright`](https://www.npmjs.com/package/@axe-core/playwright) against
+key page templates (front page, a landing page, a news article, the login page,
+and the 404 page). The suite lives in `accessibility-testing/` and requires a
+running DDEV site (`ddev start`, with the site installed per the
+["Local Installation"](#local-installation) steps above).
+
+```bash
+cd accessibility-testing
+npm ci
+npx playwright install --with-deps
+
+# Run the suite (targets http://drupal-starter.ddev.site:8880 by default,
+# override with BASE_URL).
+npx playwright test
+
+# Open the HTML report; each test's Attachments section links to the
+# full WCAG violation report for that page.
+npx playwright show-report
+```
+
+This suite also runs automatically in CI via `.github/workflows/playwright.yml`,
+which builds a fresh DDEV site inside the runner (the same way `ci.yml` does for
+PHPUnit) so no hosted environment is needed.
+
 ## Debugging
 
 ## Visual Studio Code instructions

--- a/accessibility-testing/.gitignore
+++ b/accessibility-testing/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/accessibility-testing/.gitignore
+++ b/accessibility-testing/.gitignore
@@ -1,3 +1,0 @@
-node_modules/
-playwright-report/
-test-results/

--- a/accessibility-testing/package-lock.json
+++ b/accessibility-testing/package-lock.json
@@ -1,0 +1,148 @@
+{
+  "name": "drupal-starter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "drupal-starter",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
+        "@playwright/test": "^1.62.1",
+        "@types/node": "^26.4.0",
+        "axe-html-reporter": "^2.2.11"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-html-reporter": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.11.tgz",
+      "integrity": "sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mustache": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      },
+      "peerDependencies": {
+        "axe-core": ">=3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/accessibility-testing/package.json
+++ b/accessibility-testing/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "drupal-starter",
+  "version": "1.0.0",
+  "description": "[![Build Status](https://github.com/Gizra/drupal-starter/actions/workflows/ci.yml/badge.svg)](https://github.com/Gizra/drupal-starter/actions)",
+  "main": "index.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Gizra/drupal-starter.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/Gizra/drupal-starter/issues"
+  },
+  "homepage": "https://github.com/Gizra/drupal-starter#readme",
+  "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
+    "@playwright/test": "^1.62.1",
+    "@types/node": "^26.4.0",
+    "axe-html-reporter": "^2.2.11"
+  }
+}

--- a/accessibility-testing/playwright.config.js
+++ b/accessibility-testing/playwright.config.js
@@ -39,15 +39,15 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/accessibility-testing/playwright.config.js
+++ b/accessibility-testing/playwright.config.js
@@ -1,14 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
-
-/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
@@ -39,41 +31,5 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
 
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
-
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  ]
 });

--- a/accessibility-testing/playwright.config.js
+++ b/accessibility-testing/playwright.config.js
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    baseURL: process.env.BASE_URL || 'http://drupal-starter.ddev.site:8880',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://localhost:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/accessibility-testing/tests/accessibility-cases.spec.js
+++ b/accessibility-testing/tests/accessibility-cases.spec.js
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import path from 'path';
+import { createHtmlReport } from 'axe-html-reporter';
+
+// WCAG 2.2 AA tags are not cumulative with 2.1/2.0 in axe-core's tag
+// scheme, so all three sets must be requested explicitly.
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'];
+
+// Key page templates seeded by server_default_content - the set a fresh
+// client build inherits without needing any project-specific content.
+const PAGES = [
+  { name: 'front-page', path: '/' },
+  { name: 'landing-page', path: '/contact' },
+  { name: 'news-article', path: '/news/blind-texts' },
+  { name: 'login-page', path: '/user/login' },
+  { name: '404-page', path: '/this-page-does-not-exist' },
+];
+
+test.describe('WCAG 2.2 AA Accessibility', () => {
+  for (const { name, path: pagePath } of PAGES) {
+    test(`Accessibility - ${name}`, async ({ page }, testInfo) => {
+      await page.goto(pagePath);
+      await page.waitForLoadState('networkidle');
+
+      const accessibilityScanResults = await new AxeBuilder({ page })
+        .withTags(WCAG_TAGS)
+        .analyze();
+
+      const reportDir = path.join('test-results', 'accessibility-reports');
+      const reportFileName = `${name}.html`;
+      createHtmlReport({
+        results: accessibilityScanResults,
+        options: {
+          outputDir: reportDir,
+          reportFileName,
+        },
+      });
+
+      // Attach the WCAG report so it's viewable from within the Playwright
+      // HTML report, instead of a separate directory.
+      await testInfo.attach(`WCAG report - ${name}`, {
+        path: path.join(reportDir, reportFileName),
+        contentType: 'text/html',
+      });
+
+      expect(accessibilityScanResults.violations).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
https://github.com/Gizra/drupal-starter/issues/1072

- We're adding a Playwright/axe-core WCAG 2.2 AA suite to the Drupal starter, verified working with real violations found on two pages. Just added a README section documenting how to run it.

- Added the code for the html report as well

- Added for the following pages:
Front page
A landing_page node
A news node
/user/login
The 404 page


TB: 2/2