### PR TITLE
#1070 Add AI-crawler-aware robots.txt baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,8 +549,11 @@ vendor runs separate bots for model training, search-indexing, and
 live user-triggered retrieval (e.g. OpenAI's `GPTBot` / `OAI-SearchBot` /
 `ChatGPT-User`), so they are listed individually and can be tuned per bot.
 
-The baseline **allows** every named AI bot full access to your original
-content, with one exception: `Google-Extended` is disallowed, which is a free
+The baseline **allows** every named AI bot access to your original content,
+with two exceptions. First, faceted-search URLs are disallowed for the AI bots
+too — the same protection `User-agent: *` gets — since crawling facet
+permutations has no value for any bot and only wastes crawl budget and server
+resources. Second, `Google-Extended` is disallowed entirely, which is a free
 opt-out from Gemini/Vertex model training and has no effect on Google Search
 or AI Overviews. Revisit this policy per project on the Go Live Checklist.
 
@@ -558,11 +561,13 @@ or AI Overviews. Revisit this policy per project on the Go Live Checklist.
 
 `robots.txt` groups do **not** merge: a bot obeys only the single most
 specific `User-agent` group matching its name. To keep a training bot out of a
-rights-restricted collection while allowing it everywhere else, replace that
-bot's blanket `Disallow:` (empty = allow all) with path-scoped rules:
+rights-restricted collection while allowing it everywhere else, add path-scoped
+rules to that bot's group alongside the facet ones:
 
 ```
 User-agent: GPTBot
+Disallow: *?f%5B*
+Disallow: *&f%5B*
 Disallow: /licensed-collection/
 Disallow: /archive/rights-restricted/
 ```

--- a/README.md
+++ b/README.md
@@ -542,6 +542,44 @@ ddev auth ssh # One-time prerequisite
 ddev robo security:access-log-overview
 ```
 
+## AI crawlers
+
+`web/robots.txt` ships an explicit, per-vendor baseline for AI bots. Each
+vendor runs separate bots for model training, search-indexing, and
+live user-triggered retrieval (e.g. OpenAI's `GPTBot` / `OAI-SearchBot` /
+`ChatGPT-User`), so they are listed individually and can be tuned per bot.
+
+The baseline **allows** every named AI bot full access to your original
+content, with one exception: `Google-Extended` is disallowed, which is a free
+opt-out from Gemini/Vertex model training and has no effect on Google Search
+or AI Overviews. Revisit this policy per project on the Go Live Checklist.
+
+### Restricting a training bot to part of the site
+
+`robots.txt` groups do **not** merge: a bot obeys only the single most
+specific `User-agent` group matching its name. To keep a training bot out of a
+rights-restricted collection while allowing it everywhere else, replace that
+bot's blanket `Disallow:` (empty = allow all) with path-scoped rules:
+
+```
+User-agent: GPTBot
+Disallow: /licensed-collection/
+Disallow: /archive/rights-restricted/
+```
+
+Scope by the URL path of the content type or collection you need to protect.
+
+### Verifying bot identity
+
+A `robots.txt` rule is only honored by well-behaved bots, and any client can
+send a `User-agent: GPTBot` header. To *enforce* a policy — or to trust a bot's
+identity before serving it — verify the request against the vendor's published
+IP ranges or via forward-confirmed reverse DNS (rDNS: the source IP must
+reverse-resolve to the vendor's domain, and that hostname must forward-resolve
+back to the same IP). This is best done at the CDN/WAF layer (e.g. Cloudflare
+verified-bot rules). Vendors publish the required IP ranges and rDNS domains in
+the bot docs linked from `robots.txt`.
+
 ## Importing/Exporting translations
 
 There are 2 types of translations that we manage in this site by code. These are:

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRobotsTxtTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRobotsTxtTest.php
@@ -45,6 +45,15 @@ class ServerGeneralRobotsTxtTest extends ExistingSiteBase {
     // site to opt out of Gemini/Vertex training.
     $google_extended = strstr($content, 'User-agent: Google-Extended');
     $this->assertStringContainsString('Disallow: /', $google_extended, 'Google-Extended is disallowed from the entire site.');
+
+    // Faceted-search URLs have no crawl value for any bot. Because robots.txt
+    // groups do not merge, each AI bot group must repeat the facet protection
+    // instead of inheriting it from "User-agent: *".
+    $this->assertGreaterThanOrEqual(
+      2,
+      substr_count($content, 'Disallow: *?f%5B*'),
+      'The facet protection is repeated inside the AI-bot groups, not only in "User-agent: *".'
+    );
   }
 
 }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRobotsTxtTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralRobotsTxtTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Symfony\Component\HttpFoundation\Response;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Tests the AI-crawler baseline shipped in robots.txt.
+ */
+class ServerGeneralRobotsTxtTest extends ExistingSiteBase {
+
+  /**
+   * Tests that robots.txt declares an explicit, per-vendor AI-bot policy.
+   */
+  public function testRobotsTxtAiBots() {
+    $this->drupalGet('/robots.txt');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $content = $this->getSession()->getPage()->getContent();
+
+    // Each AI bot family must be named explicitly, so the policy can be tuned
+    // per vendor and per bot rather than relying on a blanket "AI bot" rule.
+    $expected_user_agents = [
+      // OpenAI.
+      'GPTBot',
+      'OAI-SearchBot',
+      'ChatGPT-User',
+      // Anthropic.
+      'ClaudeBot',
+      'Claude-SearchBot',
+      'Claude-User',
+      // Perplexity.
+      'PerplexityBot',
+      'Perplexity-User',
+      // Meta.
+      'Meta-ExternalAgent',
+      // Google training opt-out.
+      'Google-Extended',
+    ];
+    foreach ($expected_user_agents as $user_agent) {
+      $this->assertStringContainsString("User-agent: $user_agent", $content, "robots.txt names the $user_agent bot.");
+    }
+
+    // Google-Extended is the one opt-out: it must be disallowed from the whole
+    // site to opt out of Gemini/Vertex training.
+    $google_extended = strstr($content, 'User-agent: Google-Extended');
+    $this->assertStringContainsString('Disallow: /', $google_extended, 'Google-Extended is disallowed from the entire site.');
+  }
+
+}

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -84,18 +84,21 @@ Disallow: *&f%5B*
 # live user prompt. They are listed per vendor and per bot below so the
 # policy can be tuned for each one, per project.
 #
-# Baseline policy: ALLOW every named AI bot full access to our original
-# content (retrieval, indexing, and training). "Disallow:" with an empty
-# value means "allow everything" for that group. The only opt-out is
+# Baseline policy: ALLOW every named AI bot access to our original content
+# (retrieval, indexing, and training), EXCEPT the faceted-search URLs. Crawling
+# facet permutations is pure waste — no bot gains value from indexing them, and
+# they burn crawl budget and server resources — so we keep the same facet
+# protection here that "User-agent: *" gets above. The only full opt-out is
 # Google-Extended (see the end of this section).
 #
 # NOTE: robots.txt groups do NOT merge. A bot obeys only the single most
 # specific "User-agent" group that matches its name, so each group below is
-# self-contained and does not inherit the "User-agent: *" rules above.
+# self-contained and does not inherit the "User-agent: *" rules above. That is
+# why the facet "Disallow:" lines are repeated in every group.
 #
 # To keep a *training* bot out of a rights-restricted collection while still
-# allowing it everywhere else, replace the empty "Disallow:" with one or more
-# path-scoped rules, e.g.:
+# allowing it everywhere else, add path-scoped rules alongside the facet ones,
+# e.g.:
 #
 #   User-agent: GPTBot
 #   Disallow: /licensed-collection/
@@ -108,25 +111,29 @@ Disallow: *&f%5B*
 User-agent: GPTBot
 User-agent: OAI-SearchBot
 User-agent: ChatGPT-User
-Disallow:
+Disallow: *?f%5B*
+Disallow: *&f%5B*
 
 # Anthropic — https://support.anthropic.com/en/articles/8896518
 # ClaudeBot: model training. Claude-SearchBot: search index. Claude-User: live user fetch.
 User-agent: ClaudeBot
 User-agent: Claude-SearchBot
 User-agent: Claude-User
-Disallow:
+Disallow: *?f%5B*
+Disallow: *&f%5B*
 
 # Perplexity — https://docs.perplexity.ai/guides/bots
 # PerplexityBot: search index. Perplexity-User: live user fetch.
 User-agent: PerplexityBot
 User-agent: Perplexity-User
-Disallow:
+Disallow: *?f%5B*
+Disallow: *&f%5B*
 
 # Meta — https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
 # Meta-ExternalAgent: model training and AI product indexing.
 User-agent: Meta-ExternalAgent
-Disallow:
+Disallow: *?f%5B*
+Disallow: *&f%5B*
 
 # Google-Extended — opt OUT of Gemini/Vertex model training. This is free and
 # has NO effect on Google Search indexing or on AI Overviews.

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -75,3 +75,61 @@ Disallow: /index.php/*/media/oembed
 # @see https://acquia.my.site.com/s/article/How-do-I-manage-an-application-that-receives-lots-of-requests-for-faceted-searches
 Disallow: *?f%5B*
 Disallow: *&f%5B*
+
+# ---------------------------------------------------------------------------
+# AI crawlers
+#
+# Each vendor runs several independently-controlled bots: some train models,
+# some build a search index, and some fetch a single page in response to a
+# live user prompt. They are listed per vendor and per bot below so the
+# policy can be tuned for each one, per project.
+#
+# Baseline policy: ALLOW every named AI bot full access to our original
+# content (retrieval, indexing, and training). "Disallow:" with an empty
+# value means "allow everything" for that group. The only opt-out is
+# Google-Extended (see the end of this section).
+#
+# NOTE: robots.txt groups do NOT merge. A bot obeys only the single most
+# specific "User-agent" group that matches its name, so each group below is
+# self-contained and does not inherit the "User-agent: *" rules above.
+#
+# To keep a *training* bot out of a rights-restricted collection while still
+# allowing it everywhere else, replace the empty "Disallow:" with one or more
+# path-scoped rules, e.g.:
+#
+#   User-agent: GPTBot
+#   Disallow: /licensed-collection/
+#   Disallow: /archive/rights-restricted/
+#
+# See the README ("AI crawlers") for the full pattern.
+
+# OpenAI — https://platform.openai.com/docs/bots
+# GPTBot: model training. OAI-SearchBot: search index. ChatGPT-User: live user fetch.
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
+Disallow:
+
+# Anthropic — https://support.anthropic.com/en/articles/8896518
+# ClaudeBot: model training. Claude-SearchBot: search index. Claude-User: live user fetch.
+User-agent: ClaudeBot
+User-agent: Claude-SearchBot
+User-agent: Claude-User
+Disallow:
+
+# Perplexity — https://docs.perplexity.ai/guides/bots
+# PerplexityBot: search index. Perplexity-User: live user fetch.
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+Disallow:
+
+# Meta — https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
+# Meta-ExternalAgent: model training and AI product indexing.
+User-agent: Meta-ExternalAgent
+Disallow:
+
+# Google-Extended — opt OUT of Gemini/Vertex model training. This is free and
+# has NO effect on Google Search indexing or on AI Overviews.
+# https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers
+User-agent: Google-Extended
+Disallow: /


### PR DESCRIPTION
Closes #1070.

## What
Replaces the stock Drupal scaffold `robots.txt` with an explicit, commented, per-vendor baseline for AI crawlers.

- **Names each bot family separately** — OpenAI (`GPTBot`/`OAI-SearchBot`/`ChatGPT-User`), Anthropic (`ClaudeBot`/`Claude-SearchBot`/`Claude-User`), Perplexity (`PerplexityBot`/`Perplexity-User`), Meta (`Meta-ExternalAgent`) — so the policy is tunable per bot, per project.
- **Default: allow** all named AI bots full access to original content (retrieval, index, training).
- **Opts out of `Google-Extended`** (`Disallow: /`), the free Gemini/Vertex training opt-out that doesn't affect Search or AI Overviews.
- **README "AI crawlers"** documents the path-scoped pattern for restricting a training bot to part of the site, and bot-identity verification (IP range / rDNS, best at the CDN/WAF layer).
- **Test** — `ServerGeneralRobotsTxtTest` asserts every bot is named and Google-Extended is disallowed.

The `robots.txt` scaffold override is already pinned to `false` in `composer.json`, so this file is managed by the project and won't be overwritten.

## Follow-up
The CDN/WAF IP/rDNS *enforcement* (issue item 4) as an optional PHP snippet lands in a separate PR, since it's infra-flavored and may not belong in the app layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)