### PR TITLE
#1071 Reusable JSON-LD sameAs authority link builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,32 @@ Entity rendering via PEVB plugins. Example: `web/modules/custom/server_general/s
 
 View modes and display configurations must be defined in code via PEVB plugins, not through Drupal's UI manage display.
 
+### Structured Data: sameAs Authority Links
+
+The `server_general.same_as_link_builder` service
+(`Drupal\server_general\JsonLd\SameAsLinkBuilder`) maps an entity's external
+authority identifiers (Wikidata, VIAF, ORCID, WorldCat) to schema.org `sameAs`
+URLs and a stable `@id`, for use in JSON-LD structured data. This links a page
+to the real-world entity it describes so search engines and knowledge graphs
+can merge references across sites.
+
+**`@id`-stability convention** (follow by default): the `@id` must be a
+globally stable authority URI, never a site-local node URL — node paths change
+across environments and edits, authority URIs never do. The builder derives
+`@id` from the highest-priority identifier present, in order: Wikidata → VIAF →
+ORCID → WorldCat. Give linkable entities a Wikidata ID where one exists and let
+the builder emit both `sameAs` and `@id`; do not hand-write `@id`. See the
+interface docblock for the full rationale.
+
+**Reference example:** the `news` content type carries a `field_wikidata_id`
+field (a plain Q-ID such as `Q42`), and several default-content news nodes set
+it. Feed it to the builder via the field map:
+```php
+$builder = \Drupal::service('server_general.same_as_link_builder');
+$data = $builder->buildForEntity($node, ['wikidata' => 'field_wikidata_id']);
+// $data == ['@id' => 'https://www.wikidata.org/wiki/Q8', 'sameAs' => [...]]
+```
+
 ### Responsive Images
 1. Define component rules (how images transform at breakpoints)
 2. Determine largest dimensions per breakpoint

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_metatag
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
+    - field.field.node.news.field_wikidata_id
     - node.type.news
     - workflows.workflow.default
   module:
@@ -46,7 +47,7 @@ content:
     third_party_settings: {  }
   field_metatag:
     type: metatag_firehose
-    weight: 101
+    weight: 16
     region: content
     settings:
       sidebar: true
@@ -54,7 +55,7 @@ content:
     third_party_settings: {  }
   field_publish_date:
     type: datetime_default
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -70,6 +71,15 @@ content:
       show_entity_id: 0
       show_info_label: 0
       info_label: ''
+      parent_selection: 1
+    third_party_settings: {  }
+  field_wikidata_id:
+    type: string_textfield
+    weight: 17
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   langcode:
     type: language_select
@@ -80,7 +90,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -104,7 +114,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 12
+    weight: 13
     region: content
     settings:
       display_label: true
@@ -125,7 +135,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -140,7 +150,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.news.default.yml
+++ b/config/sync/core.entity_view_display.node.news.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_metatag
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
+    - field.field.node.news.field_wikidata_id
     - node.type.news
   module:
     - datetime
@@ -69,5 +70,6 @@ content:
     weight: 100
     region: content
 hidden:
+  field_wikidata_id: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.news.search_index.yml
+++ b/config/sync/core.entity_view_display.node.news.search_index.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.news.field_metatag
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
+    - field.field.node.news.field_wikidata_id
     - node.type.news
   module:
     - datetime
@@ -63,5 +64,6 @@ content:
     region: content
 hidden:
   field_metatag: true
+  field_wikidata_id: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.news.teaser.yml
+++ b/config/sync/core.entity_view_display.node.news.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.news.field_metatag
     - field.field.node.news.field_publish_date
     - field.field.node.news.field_tags
+    - field.field.node.news.field_wikidata_id
     - node.type.news
   module:
     - user
@@ -33,5 +34,6 @@ hidden:
   field_metatag: true
   field_publish_date: true
   field_tags: true
+  field_wikidata_id: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/field.field.node.news.field_wikidata_id.yml
+++ b/config/sync/field.field.node.news.field_wikidata_id.yml
@@ -1,0 +1,19 @@
+uuid: 301a0f08-28b5-4e5a-b74a-4545c2756cb4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_wikidata_id
+    - node.type.news
+id: node.news.field_wikidata_id
+field_name: field_wikidata_id
+entity_type: node
+bundle: news
+label: 'Wikidata ID'
+description: 'The Wikidata Q-ID for the real-world entity this content is about (e.g. Q42). Used to build schema.org sameAs links and a stable @id in JSON-LD.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_wikidata_id.yml
+++ b/config/sync/field.storage.node.field_wikidata_id.yml
@@ -1,0 +1,21 @@
+uuid: 247a0b44-ce26-4be8-ac1f-ad04afd37ea6
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_wikidata_id
+field_name: field_wikidata_id
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/server_default_content/content/node/19a403eb-f571-4684-819e-239348ef2ef2.yml
+++ b/web/modules/custom/server_default_content/content/node/19a403eb-f571-4684-819e-239348ef2ef2.yml
@@ -68,3 +68,6 @@ default:
   field_tags:
     -
       entity: 36e37c28-d3d4-45df-88ba-0ef7f9e82fe4
+  field_wikidata_id:
+    -
+      value: Q8

--- a/web/modules/custom/server_default_content/content/node/f1dd02df-ef2f-4cc2-bd41-cf4ff0c34e01.yml
+++ b/web/modules/custom/server_default_content/content/node/f1dd02df-ef2f-4cc2-bd41-cf4ff0c34e01.yml
@@ -71,3 +71,6 @@ default:
       entity: 36e37c28-d3d4-45df-88ba-0ef7f9e82fe4
     -
       entity: e021e646-55ed-455b-add6-3e635008173b
+  field_wikidata_id:
+    -
+      value: Q39809

--- a/web/modules/custom/server_default_content/content/node/fdfc2b97-a826-4887-8218-fb3a3add5f72.yml
+++ b/web/modules/custom/server_default_content/content/node/fdfc2b97-a826-4887-8218-fb3a3add5f72.yml
@@ -71,3 +71,6 @@ default:
       entity: f05daf9b-d532-499e-96ff-dd627cf685d0
     -
       entity: e021e646-55ed-455b-add6-3e635008173b
+  field_wikidata_id:
+    -
+      value: Q8434

--- a/web/modules/custom/server_general/server_general.services.yml
+++ b/web/modules/custom/server_general/server_general.services.yml
@@ -1,4 +1,6 @@
 services:
+  server_general.same_as_link_builder:
+    class: Drupal\server_general\JsonLd\SameAsLinkBuilder
   server_general.locked_pages:
     class: Drupal\server_general\LockedPages
     arguments: ['@entity_type.manager', '@entity_field.manager']

--- a/web/modules/custom/server_general/src/JsonLd/SameAsLinkBuilder.php
+++ b/web/modules/custom/server_general/src/JsonLd/SameAsLinkBuilder.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general\JsonLd;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+
+/**
+ * Default implementation of the sameAs link builder.
+ *
+ * See the interface for the @id-stability convention this service enforces.
+ */
+class SameAsLinkBuilder implements SameAsLinkBuilderInterface {
+
+  /**
+   * Supported authorities, in @id-priority order.
+   *
+   * The array order is significant: the first authority that yields a valid
+   * identifier provides the stable `@id`. Each entry defines:
+   * - 'url': The URL prefix an identifier is appended to.
+   * - 'pattern': A regular expression the raw identifier must match. Guards
+   *   against emitting broken URLs from malformed input; an identifier that
+   *   fails the pattern is skipped.
+   */
+  protected const AUTHORITIES = [
+    'wikidata' => [
+      'url' => 'https://www.wikidata.org/wiki/',
+      'pattern' => '/^Q[1-9][0-9]*$/',
+    ],
+    'viaf' => [
+      'url' => 'https://viaf.org/viaf/',
+      'pattern' => '/^[1-9][0-9]*$/',
+    ],
+    'orcid' => [
+      'url' => 'https://orcid.org/',
+      'pattern' => '/^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/',
+    ],
+    'worldcat' => [
+      'url' => 'https://search.worldcat.org/title/',
+      'pattern' => '/^[1-9][0-9]*$/',
+    ],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(array $identifiers): array {
+    $same_as = [];
+    $stable_id = NULL;
+
+    // Iterate over the authorities in priority order, not over the caller's
+    // input order, so the derived @id is deterministic regardless of how the
+    // identifiers were passed in.
+    foreach (self::AUTHORITIES as $authority => $info) {
+      if (empty($identifiers[$authority])) {
+        continue;
+      }
+
+      foreach ((array) $identifiers[$authority] as $raw_id) {
+        $id = trim((string) $raw_id);
+        if ($id === '' || !preg_match($info['pattern'], $id)) {
+          continue;
+        }
+
+        $url = $info['url'] . $id;
+        $same_as[] = $url;
+
+        // The first valid identifier in priority order defines the @id.
+        $stable_id ??= $url;
+      }
+    }
+
+    $result = [];
+    if ($stable_id !== NULL) {
+      $result['@id'] = $stable_id;
+    }
+    if (!empty($same_as)) {
+      $result['sameAs'] = array_values(array_unique($same_as));
+    }
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForEntity(FieldableEntityInterface $entity, array $field_map): array {
+    $identifiers = [];
+
+    foreach ($field_map as $authority => $field_name) {
+      if (!$entity->hasField($field_name) || $entity->get($field_name)->isEmpty()) {
+        continue;
+      }
+
+      foreach ($entity->get($field_name)->getValue() as $item) {
+        // Support both plain value fields and link fields.
+        $value = $item['value'] ?? $item['uri'] ?? '';
+        if ($value !== '') {
+          $identifiers[$authority][] = $value;
+        }
+      }
+    }
+
+    return $this->build($identifiers);
+  }
+
+}

--- a/web/modules/custom/server_general/src/JsonLd/SameAsLinkBuilderInterface.php
+++ b/web/modules/custom/server_general/src/JsonLd/SameAsLinkBuilderInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general\JsonLd;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+
+/**
+ * Builds schema.org sameAs links and a stable @id from authority identifiers.
+ *
+ * External authority records (Wikidata, VIAF, ORCID, WorldCat) uniquely and
+ * durably identify a real-world entity — a person, a work, an organization.
+ * Emitting them as schema.org `sameAs` values, together with a stable `@id`,
+ * lets search engines and knowledge graphs merge every page that references the
+ * same entity into a single node in their graph.
+ *
+ * ## The @id-stability convention
+ *
+ * The `@id` must be a globally stable, canonical URI for the real-world entity,
+ * NOT a site-local URL. A node's canonical path changes across environments
+ * (local, staging, production), when the alias is edited, or when content is
+ * migrated — so it can never serve as a durable graph identifier. An authority
+ * URI never changes: `https://www.wikidata.org/wiki/Q42` denotes the same
+ * entity forever, on every site that references it.
+ *
+ * This builder therefore derives `@id` from the highest-priority authority
+ * identifier available, in this order:
+ *
+ *   1. Wikidata  — broadest cross-domain coverage and the richest hub of
+ *                  onward links, so it makes the most useful `@id`.
+ *   2. VIAF      — authoritative for people and organizations.
+ *   3. ORCID     — authoritative for researchers.
+ *   4. WorldCat  — authoritative for bibliographic works.
+ *
+ * New projects should follow this convention by default: give every linkable
+ * entity a Wikidata ID where one exists, and let the builder derive both the
+ * `sameAs` array and the stable `@id` from it. Do not hand-write `@id` as a
+ * node URL.
+ */
+interface SameAsLinkBuilderInterface {
+
+  /**
+   * Builds the @id and sameAs values for a set of authority identifiers.
+   *
+   * @param array $identifiers
+   *   Authority identifiers keyed by authority machine name. Supported keys are
+   *   'wikidata', 'viaf', 'orcid' and 'worldcat'. Each value may be a single
+   *   identifier or an array of identifiers. Empty, whitespace-only or
+   *   malformed identifiers are skipped. Examples:
+   *   @code
+   *   [
+   *     'wikidata' => 'Q42',
+   *     'viaf' => ['113230702', '75121530'],
+   *     'orcid' => '0000-0002-1825-0097',
+   *   ]
+   *   @endcode
+   *
+   * @return array
+   *   An array that may contain:
+   *   - '@id': The stable canonical URI, derived per the @id-stability
+   *     convention. Omitted when no valid identifier is given.
+   *   - 'sameAs': A de-duplicated, order-stable list of authority URLs. Omitted
+   *     when no valid identifier is given.
+   *   Merge the result into the JSON-LD object it describes.
+   */
+  public function build(array $identifiers): array;
+
+  /**
+   * Builds the @id and sameAs values from an entity's fields.
+   *
+   * A thin convenience over ::build() that reads identifier strings from the
+   * entity's fields. It intentionally takes no field names of its own: the
+   * caller maps each authority to whatever field holds it, keeping the service
+   * decoupled from any single project's field schema.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity to read identifiers from.
+   * @param array $field_map
+   *   Maps an authority machine name (see ::build()) to the machine name of the
+   *   field holding its identifier(s). Missing or empty fields are skipped. All
+   *   values of multi-value fields are used. Example:
+   *   @code
+   *   ['wikidata' => 'field_wikidata_id', 'viaf' => 'field_viaf_id']
+   *   @endcode
+   *
+   * @return array
+   *   The same structure as ::build().
+   */
+  public function buildForEntity(FieldableEntityInterface $entity, array $field_map): array;
+
+}

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeNewsTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralNodeNewsTest.php
@@ -32,6 +32,7 @@ class ServerGeneralNodeNewsTest extends ServerGeneralNodeTestBase {
     return [
       'field_featured_image',
       'field_tags',
+      'field_wikidata_id',
     ];
   }
 

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSameAsLinkBuilderTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralSameAsLinkBuilderTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Drupal\server_general\JsonLd\SameAsLinkBuilderInterface;
+
+/**
+ * Tests the sameAs link builder service.
+ *
+ * The identifiers below (Wikidata Q42, its VIAF record, a public test ORCID and
+ * an OCLC number) are unrelated example authorities used only to exercise the
+ * mapping.
+ */
+class ServerGeneralSameAsLinkBuilderTest extends ServerGeneralTestBase {
+
+  /**
+   * The service under test.
+   *
+   * @var \Drupal\server_general\JsonLd\SameAsLinkBuilderInterface
+   */
+  protected SameAsLinkBuilderInterface $builder;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $this->builder = $this->container->get('server_general.same_as_link_builder');
+  }
+
+  /**
+   * Tests that every supported authority maps to its canonical URL.
+   */
+  public function testBuildAllAuthorities(): void {
+    $result = $this->builder->build([
+      'wikidata' => 'Q42',
+      'viaf' => '113230702',
+      'orcid' => '0000-0002-1825-0097',
+      'worldcat' => '44954653',
+    ]);
+
+    $this->assertEquals([
+      'https://www.wikidata.org/wiki/Q42',
+      'https://viaf.org/viaf/113230702',
+      'https://orcid.org/0000-0002-1825-0097',
+      'https://search.worldcat.org/title/44954653',
+    ], $result['sameAs']);
+  }
+
+  /**
+   * Tests that @id follows the stability convention's priority order.
+   *
+   * Wikidata outranks VIAF, which outranks ORCID, which outranks WorldCat —
+   * regardless of the order the identifiers are passed in.
+   */
+  public function testStableIdPriority(): void {
+    // Wikidata wins when present, even when passed last.
+    $result = $this->builder->build([
+      'worldcat' => '44954653',
+      'orcid' => '0000-0002-1825-0097',
+      'viaf' => '113230702',
+      'wikidata' => 'Q42',
+    ]);
+    $this->assertEquals('https://www.wikidata.org/wiki/Q42', $result['@id']);
+
+    // Falls back to VIAF when Wikidata is absent.
+    $result = $this->builder->build([
+      'worldcat' => '44954653',
+      'viaf' => '113230702',
+    ]);
+    $this->assertEquals('https://viaf.org/viaf/113230702', $result['@id']);
+
+    // Falls back to WorldCat when it is the only authority.
+    $result = $this->builder->build(['worldcat' => '44954653']);
+    $this->assertEquals('https://search.worldcat.org/title/44954653', $result['@id']);
+  }
+
+  /**
+   * Tests that empty and malformed identifiers are skipped.
+   */
+  public function testInvalidIdentifiersAreSkipped(): void {
+    // No valid input yields an empty result, not a broken @id or URL.
+    $this->assertSame([], $this->builder->build([]));
+    $this->assertSame([], $this->builder->build([
+      'wikidata' => '',
+      'viaf' => '   ',
+      // Missing the Q prefix.
+      'orcid' => 'not-an-orcid',
+    ]));
+
+    // A malformed high-priority id is skipped so a valid lower-priority id
+    // still provides the @id.
+    $result = $this->builder->build([
+      'wikidata' => '42',
+      'viaf' => '113230702',
+    ]);
+    $this->assertEquals('https://viaf.org/viaf/113230702', $result['@id']);
+    $this->assertEquals(['https://viaf.org/viaf/113230702'], $result['sameAs']);
+  }
+
+  /**
+   * Tests multi-value input and de-duplication.
+   */
+  public function testMultipleValuesAreDeduplicated(): void {
+    $result = $this->builder->build([
+      'viaf' => ['113230702', '113230702', '75121530'],
+    ]);
+
+    $this->assertEquals([
+      'https://viaf.org/viaf/113230702',
+      'https://viaf.org/viaf/75121530',
+    ], $result['sameAs']);
+  }
+
+  /**
+   * Tests reading identifiers from an entity's fields.
+   */
+  public function testBuildForEntity(): void {
+    // The title field is used as an arbitrary string source here; the field map
+    // decouples the service from any specific project's field schema.
+    $node = $this->createNode([
+      'title' => 'Q42',
+      'type' => 'news',
+      'moderation_state' => 'published',
+    ]);
+
+    $result = $this->builder->buildForEntity($node, [
+      'wikidata' => 'title',
+      // A field that does not exist on the node is skipped gracefully.
+      'viaf' => 'field_does_not_exist',
+    ]);
+
+    $this->assertEquals('https://www.wikidata.org/wiki/Q42', $result['@id']);
+    $this->assertEquals(['https://www.wikidata.org/wiki/Q42'], $result['sameAs']);
+  }
+
+}


### PR DESCRIPTION
Closes #1071.

Extracts Posen's Wikidata `sameAs` entity-linking into a reusable, project-agnostic service — the linking primitive only, not Posen's whole custom JSON-LD pattern.

## What to review

- `server_general.same_as_link_builder` (`JsonLd\SameAsLinkBuilder`) maps an entity's authority identifiers to schema.org `sameAs` URLs plus a stable `@id`.
- `build(array $identifiers)` — pure core, keyed by `wikidata`/`viaf`/`orcid`/`worldcat`; de-duplicates, pattern-checks IDs, skips malformed ones.
- `buildForEntity($entity, $field_map)` — reads identifiers from fields via a caller-supplied map, so the service is decoupled from any project's field schema.

## `@id`-stability convention

The `@id` is derived from the highest-priority authority present (Wikidata → VIAF → ORCID → WorldCat), never a site-local node URL — node paths change across environments and edits, authority URIs never do. Documented in the interface docblock and CLAUDE.md.

## Example wiring

The `news` type gets an optional `field_wikidata_id` (plain Q-ID); a few default-content news nodes set it (happiness `Q8`, education `Q8434`, marketing `Q39809`). The field is form-editable and hidden in view displays (it's JSON-LD metadata rendered via PEVB, and should not be search-indexed).

Note: nothing yet renders the builder output into a page `<head>` — that consumer is intentionally out of scope for #1071 (extract the service). 

## Tests

- New `ServerGeneralSameAsLinkBuilderTest` (5 tests): all authorities, `@id` priority, invalid/empty skipping, de-dup, entity reading.
- `field_wikidata_id` added to `ServerGeneralNodeNewsTest` optional fields.
- Full `ddev phpunit` green (78 + 5 sequential); `phpcs`/`phpstan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx7kA7hVEg9ZKkgGU2ZX2