### PR TITLE
#1073 Publish OpenAPI + agent-discovery catalogs for site search

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,31 @@ This project supports AI-based features using OpenAI.
 ddev terminus secret:site:set gizra-drupal-starter openai_api_key your-key-here --type=runtime --scope=web,user
 ```
 
+## Agent-queryable search
+
+The starter publishes its search so an AI agent can query it directly instead of
+scraping the HTML `/search` page:
+
+- `GET /api/search?key=<term>&type=<bundle>&limit=<n>` — anonymous, read-only
+  fulltext search over the Solr index, returning `{count, results:[{title, url,
+  snippet, type}]}`. Results respect node access, so only published, public
+  content is exposed.
+- `GET /api/search/openapi.yaml` — the OpenAPI 3.1 description of that endpoint
+  (`web/modules/custom/server_general/search.openapi.yaml`), with the live
+  origin filled in automatically.
+- `GET /.well-known/api-catalog` — an [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727)
+  linkset pointing at the OpenAPI description.
+- `GET /.well-known/ai-catalog.json` — Google's Agentic Resource Discovery
+  catalog, exposing a `description` and `representativeQueries`.
+
+**Per project**, tailor two things to the site:
+
+1. The `description` and `representativeQueries` in the
+   `server_general.agent_discovery` config (edit
+   `config/sync/server_general.agent_discovery.yml`, then `ddev drush cim`).
+2. The `info.description` in `search.openapi.yaml`, describing what content the
+   site holds.
+
 ## PHPCS (Code Sniffer)
 
     ddev phpcs

--- a/config/sync/server_general.agent_discovery.yml
+++ b/config/sync/server_general.agent_discovery.yml
@@ -1,0 +1,4 @@
+description: 'Fulltext search over this site''s published content.'
+representative_queries:
+  - 'latest news'
+  - 'about the organization'

--- a/web/modules/custom/server_general/config/install/server_general.agent_discovery.yml
+++ b/web/modules/custom/server_general/config/install/server_general.agent_discovery.yml
@@ -1,0 +1,6 @@
+# Human-facing copy published at /.well-known/ai-catalog.json. Each project
+# should replace these generic defaults with content specific to the site.
+description: 'Fulltext search over this site''s published content.'
+representative_queries:
+  - 'latest news'
+  - 'about the organization'

--- a/web/modules/custom/server_general/config/schema/server_general.agent_discovery.schema.yml
+++ b/web/modules/custom/server_general/config/schema/server_general.agent_discovery.schema.yml
@@ -1,0 +1,13 @@
+server_general.agent_discovery:
+  type: config_object
+  label: 'Agent discovery catalog'
+  mapping:
+    description:
+      type: label
+      label: 'Description published at /.well-known/ai-catalog.json'
+    representative_queries:
+      type: sequence
+      label: 'Representative queries'
+      sequence:
+        type: string
+        label: 'Query'

--- a/web/modules/custom/server_general/search.openapi.yaml
+++ b/web/modules/custom/server_general/search.openapi.yaml
@@ -1,0 +1,91 @@
+# OpenAPI description of the site's public search (GET /api/search, served by
+# server_general's AgentSearchController). It is published for AI agents via the
+# two discovery catalogs at /.well-known/api-catalog and /.well-known/ai-catalog.json.
+#
+# Per project: edit `info.description` to describe *this* site's content, and
+# keep the request/response schema in sync if you extend the endpoint. The
+# `servers[0].url` placeholder below is filled in with the live origin at request
+# time by AgentSearchController::openApiSpec(), so it does not need editing.
+openapi: 3.1.0
+info:
+  title: Site Search
+  description: >-
+    Fulltext search over the site's published content. Replace this description
+    with one specific to the project — what kinds of content live here and what
+    an agent can expect to find.
+  version: 1.0.0
+servers:
+  - url: __SITE_ORIGIN__
+    description: This Drupal site.
+paths:
+  /api/search:
+    get:
+      operationId: searchContent
+      summary: Search the site
+      # Read-only lookup. `x-openai-isConsequential` is an OpenAI-specific hint
+      # (other hosts ignore it): false lets ChatGPT offer an "Always Allow"
+      # button instead of prompting on every call.
+      x-openai-isConsequential: false
+      description: >-
+        Fulltext search over the site's published content, ranked by relevance.
+        Each result carries a title, absolute URL, plain-text snippet, and
+        content type.
+      parameters:
+        - name: key
+          in: query
+          required: true
+          schema:
+            type: string
+          description: The natural-language search term.
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >-
+            Optional content-type machine name to restrict results to (e.g.
+            `news`). Omit to search all content types.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+            default: 10
+          description: Maximum number of results to return.
+      responses:
+        '200':
+          description: >-
+            Ranked matches. A blank or unmatched query returns an empty result
+            set, not an error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+components:
+  schemas:
+    SearchResponse:
+      type: object
+      properties:
+        count:
+          type: integer
+          description: Number of results returned.
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchResult'
+    SearchResult:
+      type: object
+      properties:
+        title:
+          type: string
+        url:
+          type: string
+          description: Absolute URL of the matching page.
+        snippet:
+          type: string
+          description: Short plain-text excerpt from the content.
+        type:
+          type: string
+          description: The content type's machine name.

--- a/web/modules/custom/server_general/server_general.routing.yml
+++ b/web/modules/custom/server_general/server_general.routing.yml
@@ -1,0 +1,37 @@
+server_general.agent_search:
+  path: '/api/search'
+  defaults:
+    _controller: '\Drupal\server_general\Controller\AgentSearchController::search'
+    _title: 'Search'
+  methods: [GET]
+  requirements:
+    # Public, read-only search. The Search API `content_access` processor limits
+    # results to what the current (anonymous) user may view, so no extra gate is
+    # needed here.
+    _access: 'TRUE'
+
+server_general.agent_openapi_spec:
+  path: '/api/search/openapi.yaml'
+  defaults:
+    _controller: '\Drupal\server_general\Controller\AgentSearchController::openApiSpec'
+  methods: [GET]
+  requirements:
+    _access: 'TRUE'
+
+server_general.agent_api_catalog:
+  # RFC 9727: a linkset document advertising the site's API descriptions.
+  path: '/.well-known/api-catalog'
+  defaults:
+    _controller: '\Drupal\server_general\Controller\AgentSearchController::apiCatalog'
+  methods: [GET]
+  requirements:
+    _access: 'TRUE'
+
+server_general.agent_ai_catalog:
+  # Google Agentic Resource Discovery: a description plus representative queries.
+  path: '/.well-known/ai-catalog.json'
+  defaults:
+    _controller: '\Drupal\server_general\Controller\AgentSearchController::aiCatalog'
+  methods: [GET]
+  requirements:
+    _access: 'TRUE'

--- a/web/modules/custom/server_general/src/Controller/AgentSearchController.php
+++ b/web/modules/custom/server_general/src/Controller/AgentSearchController.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general\Controller;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Cache\CacheableJsonResponse;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\CacheableResponse;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\node\NodeInterface;
+use Drupal\search_api\IndexInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Publishes an agent-queryable search endpoint and its discovery catalogs.
+ *
+ * Three things travel together here:
+ *   - GET /api/search — a plain-JSON, anonymous fulltext search over the
+ *     `server_dev` Search API index. This is the one operation the OpenAPI spec
+ *     describes; an AI agent (or any HTTP client) can call it directly instead
+ *     of scraping the HTML search page at /search.
+ *   - GET /api/search/openapi.yaml — the static OpenAPI 3.1 description of that
+ *     endpoint, with its `servers[0].url` filled in with the live origin.
+ *   - The two discovery catalogs at /.well-known/api-catalog (RFC 9727) and
+ *     /.well-known/ai-catalog.json (Google's Agentic Resource Discovery), which
+ *     point an agent at the spec.
+ *
+ * The catalogs' human-facing text (description, representative queries) lives
+ * in the `server_general.agent_discovery` config so each project can tailor it
+ * without touching code. The search itself is deliberately thin: it owns no
+ * ranking or access logic of its own, delegating both to the Search API index
+ * (the `content_access` processor restricts results to what the caller may
+ * view, so an anonymous request only ever sees published, public nodes).
+ */
+final class AgentSearchController implements ContainerInjectionInterface {
+
+  /**
+   * The machine name of the Search API index backing the endpoint.
+   */
+  private const INDEX_ID = 'server_dev';
+
+  /**
+   * Fallback cap on results, also the maximum a caller may request.
+   */
+  private const MAX_LIMIT = 20;
+
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected ConfigFactoryInterface $configFactory,
+    protected ModuleExtensionList $moduleExtensionList,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('entity_type.manager'),
+      $container->get('config.factory'),
+      $container->get('extension.list.module'),
+    );
+  }
+
+  /**
+   * Runs one fulltext search and returns a flat JSON envelope.
+   *
+   * Query params: `key` (the fulltext term, required), `type` (an optional
+   * content-type machine name to filter by), and `limit` (1..20, default 10).
+   * The response is `{count, results:[{title, url, snippet, type}]}`; a blank
+   * `key` short-circuits to an empty, well-formed envelope rather than an
+   * error, matching the OpenAPI contract that only promises a 200.
+   */
+  public function search(Request $request): JsonResponse {
+    $key = trim((string) $request->query->get('key', ''));
+    $type = trim((string) $request->query->get('type', ''));
+    $limit = (int) $request->query->get('limit', 10);
+    $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+    $cacheability = (new CacheableMetadata())
+      // Results vary by the query args and by content changes.
+      ->addCacheContexts(['url.query_args:key', 'url.query_args:type', 'url.query_args:limit'])
+      ->addCacheTags(['node_list']);
+
+    $results = $key === '' ? [] : $this->runSearch($key, $type, $limit, $cacheability);
+
+    $response = new CacheableJsonResponse([
+      'count' => count($results),
+      'results' => $results,
+    ]);
+    $response->addCacheableDependency($cacheability);
+    return $response;
+  }
+
+  /**
+   * Serves the OpenAPI description with the live origin filled in.
+   */
+  public function openApiSpec(Request $request): Response {
+    $path = $this->moduleExtensionList->getPath('server_general') . '/search.openapi.yaml';
+    $yaml = (string) file_get_contents($path);
+    $yaml = str_replace('__SITE_ORIGIN__', $request->getSchemeAndHttpHost(), $yaml);
+
+    $response = new CacheableResponse($yaml);
+    $response->headers->set('Content-Type', 'application/yaml; charset=UTF-8');
+    $response->getCacheableMetadata()->addCacheContexts(['url.site']);
+    return $response;
+  }
+
+  /**
+   * Publishes the RFC 9727 API catalog (a linkset pointing at the spec).
+   */
+  public function apiCatalog(Request $request): JsonResponse {
+    $origin = $request->getSchemeAndHttpHost();
+    $body = [
+      'linkset' => [
+        [
+          'anchor' => $origin . '/api/search',
+          'service-desc' => [
+            [
+              'href' => $origin . '/api/search/openapi.yaml',
+              'type' => 'application/yaml',
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $response = new CacheableJsonResponse($body);
+    $response->headers->set('Content-Type', 'application/linkset+json');
+    $response->getCacheableMetadata()->addCacheContexts(['url.site']);
+    return $response;
+  }
+
+  /**
+   * Publishes the agent-discovery catalog (description + queries).
+   *
+   * Each project overrides the text via the `server_general.agent_discovery`
+   * config; the shipped defaults are generic starter copy.
+   */
+  public function aiCatalog(Request $request): JsonResponse {
+    $config = $this->configFactory->get('server_general.agent_discovery');
+    $body = [
+      'description' => (string) $config->get('description'),
+      'openapi' => $request->getSchemeAndHttpHost() . '/api/search/openapi.yaml',
+      'representativeQueries' => array_values($config->get('representative_queries') ?? []),
+    ];
+
+    $response = new CacheableJsonResponse($body);
+    $response->getCacheableMetadata()
+      ->addCacheContexts(['url.site'])
+      ->addCacheableDependency($config);
+    return $response;
+  }
+
+  /**
+   * Executes the index query and maps result items to the JSON result shape.
+   *
+   * @param string $key
+   *   The fulltext search term.
+   * @param string $type
+   *   Optional content-type machine name to filter by; '' for no filter.
+   * @param int $limit
+   *   Maximum number of results.
+   * @param \Drupal\Core\Cache\CacheableMetadata $cacheability
+   *   Collects cacheability from the node URLs generated per result.
+   *
+   * @return array<int, array{title: string, url: string, snippet: string, type: string}>
+   *   The mapped results, in relevance order.
+   */
+  private function runSearch(string $key, string $type, int $limit, CacheableMetadata $cacheability): array {
+    $index = $this->entityTypeManager
+      ->getStorage('search_api_index')
+      ->load(self::INDEX_ID);
+    if (!$index instanceof IndexInterface) {
+      return [];
+    }
+
+    $query = $index->query(['limit' => $limit]);
+    $query->keys($key);
+    if ($type !== '') {
+      $query->addCondition('type', $type);
+    }
+    $query->range(0, $limit);
+
+    $results = [];
+    foreach ($query->execute()->getResultItems() as $item) {
+      try {
+        $node = $item->getOriginalObject()->getValue();
+      }
+      catch (\Exception $e) {
+        // A stale index row whose node no longer loads: skip it.
+        continue;
+      }
+      if (!$node instanceof NodeInterface) {
+        continue;
+      }
+
+      $url = $node->toUrl('canonical', ['absolute' => TRUE])->toString(TRUE);
+      $cacheability->addCacheableDependency($url);
+
+      $results[] = [
+        'title' => $node->label(),
+        'url' => $url->getGeneratedUrl(),
+        'snippet' => $this->snippet($node),
+        'type' => $node->bundle(),
+      ];
+    }
+
+    return $results;
+  }
+
+  /**
+   * Builds a short, plain-text snippet from the node body.
+   */
+  private function snippet(NodeInterface $node): string {
+    if (!$node->hasField('field_body')) {
+      return '';
+    }
+    $body = (string) $node->get('field_body')->value;
+    // Collapse the stripped markup to a single run of whitespace before
+    // cutting, so the snippet never carries layout whitespace.
+    $text = trim(preg_replace('/\s+/', ' ', strip_tags($body)) ?? '');
+    return Unicode::truncate($text, 200, TRUE, TRUE);
+  }
+
+}

--- a/web/modules/custom/server_general/src/Controller/AgentSearchController.php
+++ b/web/modules/custom/server_general/src/Controller/AgentSearchController.php
@@ -34,12 +34,9 @@ use Symfony\Component\HttpFoundation\Response;
  *     /.well-known/ai-catalog.json (Google's Agentic Resource Discovery), which
  *     point an agent at the spec.
  *
- * The catalogs' human-facing text (description, representative queries) lives
+ * The catalogs' human-facing text lives
  * in the `server_general.agent_discovery` config so each project can tailor it
- * without touching code. The search itself is deliberately thin: it owns no
- * ranking or access logic of its own, delegating both to the Search API index
- * (the `content_access` processor restricts results to what the caller may
- * view, so an anonymous request only ever sees published, public nodes).
+ * without touching code.
  */
 final class AgentSearchController implements ContainerInjectionInterface {
 

--- a/web/modules/custom/server_general/src/Controller/AgentSearchController.php
+++ b/web/modules/custom/server_general/src/Controller/AgentSearchController.php
@@ -12,6 +12,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\node\NodeInterface;
 use Drupal\search_api\IndexInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -56,6 +57,7 @@ final class AgentSearchController implements ContainerInjectionInterface {
     protected EntityTypeManagerInterface $entityTypeManager,
     protected ConfigFactoryInterface $configFactory,
     protected ModuleExtensionList $moduleExtensionList,
+    protected LanguageManagerInterface $languageManager,
   ) {}
 
   /**
@@ -66,6 +68,7 @@ final class AgentSearchController implements ContainerInjectionInterface {
       $container->get('entity_type.manager'),
       $container->get('config.factory'),
       $container->get('extension.list.module'),
+      $container->get('language_manager'),
     );
   }
 
@@ -85,9 +88,9 @@ final class AgentSearchController implements ContainerInjectionInterface {
     $limit = max(1, min(self::MAX_LIMIT, $limit));
 
     $cacheability = (new CacheableMetadata())
-      // Results vary by the query args and by content changes.
-      ->addCacheContexts(['url.query_args:key', 'url.query_args:type', 'url.query_args:limit'])
-      ->addCacheTags(['node_list']);
+      // Results vary by the query args; content-change invalidation is added
+      // from the executed query in runSearch().
+      ->addCacheContexts(['url.query_args:key', 'url.query_args:type', 'url.query_args:limit']);
 
     $results = $key === '' ? [] : $this->runSearch($key, $type, $limit, $cacheability);
 
@@ -187,10 +190,24 @@ final class AgentSearchController implements ContainerInjectionInterface {
     if ($type !== '') {
       $query->addCondition('type', $type);
     }
+    // Mirror the HTML /search view: restrict to the interface language (with
+    // fallback) so a translated node returns once, not once per translation.
+    $langcode = $this->languageManager->getCurrentLanguage()->getId();
+    $query->addCondition('language_with_fallback', $langcode);
+    $cacheability->addCacheContexts(['languages:language_interface']);
     $query->range(0, $limit);
 
+    $resultSet = $query->execute();
+    // The index invalidates search_api_list:<index> on every indexing batch and
+    // clear, catching cron catch-up and delayed Solr commits that node_list
+    // misses; the query's own contexts carry the per-user node-grants context
+    // that content_access filtering depends on.
+    $cacheability
+      ->addCacheableDependency($query)
+      ->addCacheTags(['search_api_list:' . self::INDEX_ID]);
+
     $results = [];
-    foreach ($query->execute()->getResultItems() as $item) {
+    foreach ($resultSet->getResultItems() as $item) {
       try {
         $node = $item->getOriginalObject()->getValue();
       }

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralAgentDiscoveryTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralAgentDiscoveryTest.php
@@ -66,15 +66,16 @@ class ServerGeneralAgentDiscoveryTest extends ServerGeneralSearchTestBase {
    */
   public function testSearchReturnsEnvelope(): void {
     $title = 'Zorptastic agent discovery fixture';
+    $bodyText = 'A body mentioning quixotically rare snippet content.';
     $this->createNode([
       'title' => $title,
       'type' => 'news',
-      'body' => 'A body mentioning zorptastic content for indexing.',
+      'field_body' => $bodyText,
       'moderation_state' => 'published',
     ]);
     $this->triggerPostRequestIndexing();
 
-    $this->waitForSearchIndex(function () use ($title) {
+    $this->waitForSearchIndex(function () use ($title, $bodyText) {
       $this->drupalGet('/api/search', ['query' => ['key' => 'zorptastic']]);
       $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
       $data = $this->decodeJson();
@@ -86,6 +87,18 @@ class ServerGeneralAgentDiscoveryTest extends ServerGeneralSearchTestBase {
 
       $titles = array_column($data['results'], 'title');
       $this->assertContains($title, $titles);
+
+      // The seeded node's snippet must carry the body text, exercising the
+      // snippet() path over field_body.
+      $match = NULL;
+      foreach ($data['results'] as $result) {
+        if (($result['title'] ?? '') === $title) {
+          $match = $result;
+          break;
+        }
+      }
+      $this->assertNotNull($match, 'The seeded node is present in the results.');
+      $this->assertStringContainsString($bodyText, $match['snippet']);
 
       foreach ($data['results'] as $result) {
         $this->assertArrayHasKey('title', $result);

--- a/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralAgentDiscoveryTest.php
+++ b/web/modules/custom/server_general/tests/src/ExistingSite/ServerGeneralAgentDiscoveryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\server_general\ExistingSite;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests the agent-discovery search endpoint and its catalogs.
+ *
+ * Covers GET /api/search (the JSON search an AI agent calls), the OpenAPI
+ * description it is documented by, and the two discovery catalogs that point an
+ * agent at that description.
+ */
+class ServerGeneralAgentDiscoveryTest extends ServerGeneralSearchTestBase {
+
+  /**
+   * The API catalog is a linkset pointing at the OpenAPI description.
+   */
+  public function testApiCatalog(): void {
+    $this->drupalGet('/.well-known/api-catalog');
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(Response::HTTP_OK);
+    $assert->responseHeaderContains('Content-Type', 'application/linkset+json');
+
+    $data = $this->decodeJson();
+    $href = $data['linkset'][0]['service-desc'][0]['href'] ?? '';
+    $this->assertStringEndsWith('/api/search/openapi.yaml', $href);
+  }
+
+  /**
+   * The AI catalog exposes the configured description and queries.
+   */
+  public function testAiCatalog(): void {
+    $this->drupalGet('/.well-known/ai-catalog.json');
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(Response::HTTP_OK);
+    $assert->responseHeaderContains('Content-Type', 'application/json');
+
+    $data = $this->decodeJson();
+    $this->assertArrayHasKey('description', $data);
+    $this->assertNotEmpty($data['description']);
+    $this->assertArrayHasKey('representativeQueries', $data);
+    $this->assertIsArray($data['representativeQueries']);
+    $this->assertStringEndsWith('/api/search/openapi.yaml', $data['openapi'] ?? '');
+  }
+
+  /**
+   * The OpenAPI route serves the spec with the live origin substituted in.
+   */
+  public function testOpenApiSpec(): void {
+    $this->drupalGet('/api/search/openapi.yaml');
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(Response::HTTP_OK);
+    $assert->responseHeaderContains('Content-Type', 'application/yaml');
+
+    $body = $this->getCurrentPage()->getContent();
+    $this->assertStringContainsString('openapi: 3.1.0', $body);
+    // The placeholder must have been replaced with the request origin.
+    $this->assertStringNotContainsString('__SITE_ORIGIN__', $body);
+  }
+
+  /**
+   * A fulltext query returns the well-formed envelope with the matching node.
+   */
+  public function testSearchReturnsEnvelope(): void {
+    $title = 'Zorptastic agent discovery fixture';
+    $this->createNode([
+      'title' => $title,
+      'type' => 'news',
+      'body' => 'A body mentioning zorptastic content for indexing.',
+      'moderation_state' => 'published',
+    ]);
+    $this->triggerPostRequestIndexing();
+
+    $this->waitForSearchIndex(function () use ($title) {
+      $this->drupalGet('/api/search', ['query' => ['key' => 'zorptastic']]);
+      $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+      $data = $this->decodeJson();
+
+      $this->assertArrayHasKey('count', $data);
+      $this->assertArrayHasKey('results', $data);
+      $this->assertGreaterThan(0, $data['count']);
+      $this->assertSame($data['count'], count($data['results']));
+
+      $titles = array_column($data['results'], 'title');
+      $this->assertContains($title, $titles);
+
+      foreach ($data['results'] as $result) {
+        $this->assertArrayHasKey('title', $result);
+        $this->assertArrayHasKey('url', $result);
+        $this->assertArrayHasKey('snippet', $result);
+        $this->assertArrayHasKey('type', $result);
+      }
+    });
+  }
+
+  /**
+   * A blank query short-circuits to an empty, well-formed envelope.
+   */
+  public function testBlankQueryReturnsEmpty(): void {
+    $this->drupalGet('/api/search', ['query' => ['key' => '   ']]);
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+    $data = $this->decodeJson();
+    $this->assertSame(0, $data['count']);
+    $this->assertSame([], $data['results']);
+  }
+
+  /**
+   * Decodes the current page body as JSON.
+   *
+   * @return array
+   *   The decoded payload.
+   */
+  protected function decodeJson(): array {
+    $data = json_decode($this->getCurrentPage()->getContent(), TRUE);
+    $this->assertIsArray($data);
+    return $data;
+  }
+
+}


### PR DESCRIPTION
Fixes #1073.

Publishes the site's search so an AI agent can query it directly instead of scraping the HTML `/search` page.

## Endpoints (all anonymous, read-only)

| Path | What |
|---|---|
| `GET /api/search?key=&type=&limit=` | JSON fulltext search over the Solr index → `{count, results:[{title,url,snippet,type}]}` |
| `GET /api/search/openapi.yaml` | OpenAPI 3.1 description, live origin injected at request time |
| `GET /.well-known/api-catalog` | RFC 9727 linkset pointing at the spec |
| `GET /.well-known/ai-catalog.json` | Google Agentic Resource Discovery: `description` + `representativeQueries` |

## Per-project customization

- `description` / `representativeQueries` → `config/sync/server_general.agent_discovery.yml`
- OpenAPI `info.description` → `search.openapi.yaml`

Both documented in the README ("Agent-queryable search").

## Notes

- **No JSON:API** — search runs directly on Search API in one thin controller; this is not a JSON:API implementation. Most starter-derived sites don't enable JSON:API, and it isn't a relevance-search API anyway.
- **Anonymous-safe by construction** — the index's `content_access` processor limits results to what an anonymous user may view, so only published, public content is exposed; no route-level gate needed.
- Active site config already includes the new `agent_discovery` object (committed under `config/sync`), so no extra config step on deploy.

## Testing

`ddev phpcs` clean · `ddev phpstan` no errors · `ServerGeneralAgentDiscoveryTest` — 5 tests, 28 assertions passing (both catalogs, spec origin substitution, blank-query envelope, and a real Solr-indexed search returning the seeded node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125mKNqZjfw6uB9W1skDwSm