### PR TITLE
Fix WCAG 2.2 AA accessibility violations

### DIFF
--- a/web/sites/default/settings.fast404.php
+++ b/web/sites/default/settings.fast404.php
@@ -129,7 +129,7 @@ $settings['fast404_HTTP_status_method'] = 'FastCGI';
  * Default value for this setting is shown below. The '@path' token will be
  * replaced by the the path being requested relative to the executed script.
  */
-$settings['fast404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server. <a href="/">Go back to the homepage.</a></p></body></html>';
+$settings['fast404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server. <a href="/">Go back to the homepage.</a></p></body></html>';
 
 /**
  * By default we will show a super plain 404, because usually errors like this

--- a/web/themes/custom/server_theme/templates/server-theme-button.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-button.html.twig
@@ -3,8 +3,8 @@
 {% set actual_button_type = is_download ? 'secondary' : button_type %}
 
 {% set classes = [
-  'flex flex-row items-center gap-x-4 rounded-lg px-6 py-3 text-xl border-2 border-blue-500 hover:bg-blue-600 w-fit transition duration-300',
-  actual_button_type == 'primary' ? 'bg-blue-500 text-white hover:bg-white hover:text-blue-500 focus-visible:bg-white focus-visible:text-blue-500',
+  'flex flex-row items-center gap-x-4 rounded-lg px-6 py-3 text-xl border-2 border-blue-600 hover:bg-blue-600 w-fit transition duration-300',
+  actual_button_type == 'primary' ? 'bg-blue-600 text-white hover:bg-white hover:text-blue-600 focus-visible:bg-white focus-visible:text-blue-600',
   actual_button_type == 'secondary' ? 'text-blue-900 bg-white border-blue-900 hover:text-white hover:bg-blue-900 focus-visible:text-white focus-visible:bg-blue-900',
   actual_button_type == 'tertiary' ? 'text-white bg-emerald-900 border-emerald-900 hover:text-emerald-900 hover:bg-white focus-visible:text-emerald-900 focus-visible:bg-white',
 ] | filter(v => v) | join(' ') %}

--- a/web/themes/custom/server_theme/templates/server-theme-text-decoration--font-color.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-text-decoration--font-color.html.twig
@@ -1,7 +1,7 @@
 {% if color == 'light-gray' %}
   {% set color_class = 'text-gray-400' %}
 {% elseif color == 'gray' %}
-  {% set color_class = 'text-gray-500' %}
+  {% set color_class = 'text-gray-600' %}
 {% elseif color == 'dark-gray' %}
   {% set color_class = 'text-gray-700' %}
 {% endif %}


### PR DESCRIPTION
Fixes WCAG 2.2 AA failures caught by the `accessibility-testing/` Playwright suite. All 5 page tests pass after these changes.

## Changes

- **404 page (`html-has-lang`)** — missing paths are served by the `fast_404` module's static HTML, whose `<html>` had no `lang`. Added `lang="en" xml:lang="en"`.
- **Primary buttons (contrast, WCAG 1.4.3)** — white on `bg-blue-500` (#2b7fff) was ~3.4:1. Changed to `blue-600` (~5.2:1 on white). Also updates the hover/focus text color so those states pass too.
- **Muted gray text (contrast, WCAG 1.4.3)** — the `gray` font-color token (`text-gray-500`) on `bg-gray-100` cards was 4.40:1. Changed to `text-gray-600` (~6.9:1). This also hardens Quote / News / People teasers, which use the same token on light backgrounds.

`dist/` is gitignored, so CI recompiles the theme from these template changes.

## Notes for the reviewer

- The front-page suite initially reported `target-size` locally, but that was an artifact of a stale local cache serving unstyled pages (asset URLs baked with a CLI base path); `drush cr` cleared it and exposed the real contrast issues fixed here. A fresh CI build is styled, so the contrast fixes are what matter.
- **Latent, out of scope:** the `light-gray` token (`text-gray-400`) fails contrast on white but isn't on any tested page. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)