### PR TITLE
Check that new comments stay short in CI

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,0 +1,32 @@
+name: Comment length
+
+# Only the comments a pull request writes are measured.
+on:
+  pull_request:
+
+concurrency:
+  group: comments-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comments:
+    name: "Comment length: new comments within budget"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The merge commit and both its parents, which is all `HEAD^1` needs.
+          fetch-depth: 2
+
+      # The checker's own tests first: one that passes everything is worse
+      # than none. Stdlib only, so nothing is installed here.
+      - name: Test the checker
+        run: PYTHONPATH=ci-scripts python3 -m unittest discover -s ci-scripts/tests
+
+      # The checkout is this PR merged into its base branch's tip, and `HEAD^1`
+      # is that tip. `pull_request.base.sha` can lag behind it.
+      - name: Check new comments
+        run: python3 ci-scripts/check_comments.py --base HEAD^1

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ web/sites/all/drush
 .phpunit.result.cache
 phpunit_debug
 
+# Python
+__pycache__/
+
 # Patching leftover.
 *.orig
 *.rej

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ This is a Drupal 10/11 starter project using DDEV, Robo, Pantheon, and Drupal be
 ```bash
 ddev phpcs      # Code style check
 ddev phpstan    # Static analysis
+python3 ci-scripts/check_comments.py --base origin/main  # Comment length
 ```
 
 ### Code Comments Philosophy
@@ -64,7 +65,8 @@ Only add comments that provide value beyond the code:
 - Provide **context** not obvious from code (issue references, external requirements)
 - Describe **trade-offs** and non-obvious implications
 
-Avoid comments that restate the code.
+Avoid comments that restate the code. A comment is at most 30 words, and a
+Markdown paragraph at most 60; CI rejects longer ones a PR adds.
 
 ### Code Style Guidelines
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ scraping the HTML `/search` page:
 
     ddev phpcs
 
+## Short comments
+
+A comment is at most 30 words; a paragraph in a `.md` file at most 60. A
+docblock counts up to its first tag. CI measures only the comments a pull
+request writes. To check yours before pushing (needs Python 3 and git, not
+DDEV):
+
+    python3 ci-scripts/check_comments.py --base origin/main
+
 ## Tests
 
 For testing we use [Drupal Test Traits](https://medium.com/massgovdigital/introducing-drupal-test-traits-9fe09e84384c) (DTT), as it allows a very fast and convinent way of testing existing installation profiles.

--- a/README.md
+++ b/README.md
@@ -222,12 +222,7 @@ scraping the HTML `/search` page:
 
 ## Short comments
 
-A comment is at most 30 words; a paragraph in a `.md` file at most 60. A
-docblock counts up to its first tag. CI measures only the comments a pull
-request writes. To check yours before pushing (needs Python 3 and git, not
-DDEV):
-
-    python3 ci-scripts/check_comments.py --base origin/main
+A comment is at most 30 words; a paragraph in a `.md` file at most 60.
 
 ## Tests
 

--- a/ci-scripts/check_comments.py
+++ b/ci-scripts/check_comments.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Keep new comments short.
+
+Only comment blocks a change touches are measured, so the long ones already
+in the tree stay as they are and no baseline file goes stale.
+"""
+
+import argparse
+import ast
+import fnmatch
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Words, not lines: a wrapped paragraph and a one-liner saying the same thing
+# should score the same, and a short column of names is not slop.
+CODE_BUDGET = 30
+DOC_BUDGET = 60
+
+# Drupal core's scaffold files and DDEV's config.yaml, which their updates
+# rewrite. The comments in them are not ours to shorten.
+SKIP = (
+    "/.ddev/config.yaml",
+    "/web/.ht.router.php",
+    "/web/autoload.php",
+    "/web/index.php",
+    "/web/update.php",
+    "/web/sites/default/default.*",
+    "/web/sites/example.*",
+)
+
+# DDEV starts a line with this in the add-on files it owns, and rewrites them
+# on update. Mentioning it elsewhere in a line does not count.
+DDEV_GENERATED = re.compile(r"^#ddev-generated", re.MULTILINE)
+
+# PHP has no `#` here: Drupal's standard forbids it, and `#[` opens an
+# attribute.
+LINE_COMMENT = {
+    ".css": (),
+    ".inc": ("//",),
+    ".install": ("//",),
+    ".js": ("//",),
+    ".module": ("//",),
+    ".neon": ("#",),
+    ".php": ("//",),
+    ".profile": ("//",),
+    ".py": ("#",),
+    ".sh": ("#",),
+    ".theme": ("//",),
+    ".twig": (),
+    ".yaml": ("#",),
+    ".yml": ("#",),
+}
+
+BLOCK_COMMENT = {
+    ".css": ("/*", "*/"),
+    ".inc": ("/*", "*/"),
+    ".install": ("/*", "*/"),
+    ".js": ("/*", "*/"),
+    ".module": ("/*", "*/"),
+    ".php": ("/*", "*/"),
+    ".profile": ("/*", "*/"),
+    ".theme": ("/*", "*/"),
+    ".twig": ("{#", "#}"),
+}
+
+# Files a suffix does not name.
+BY_NAME = {
+    ".gitignore": ("#",),
+}
+
+DOC_SUFFIXES = (".md",)
+
+LIST_ITEM = re.compile(r"^([-*+]|\d+[.)])\s+")
+HUNK = re.compile(r"^@@ -\S+ \+(\d+)(?:,(\d+))? @@")
+# Git ends a path holding a space with a tab.
+DIFF_FILE = re.compile(r"^\+\+\+ b/(.*?)\t?$")
+# A docblock's `/**`, `*/` and the `*` starting each of its lines.
+GUTTER = re.compile(r"^/?\*+/?\s?")
+
+
+@dataclass
+class Block:
+    """A run of comment lines, with the line numbers it covers."""
+
+    path: str
+    start: int
+    end: int
+    text: str
+    budget: int
+
+    @property
+    def words(self):
+        return len(self.text.split())
+
+
+def syntax(path):
+    """The line-comment tokens and block-comment pair a file uses."""
+    name = Path(path).name
+    if name in BY_NAME:
+        return BY_NAME[name], None
+    suffix = Path(path).suffix
+    if suffix in LINE_COMMENT or suffix in BLOCK_COMMENT:
+        return LINE_COMMENT.get(suffix, ()), BLOCK_COMMENT.get(suffix)
+    return None, None
+
+
+def wrote(written, block):
+    """Whether the change wrote any line of `block`; None stands for all."""
+    if written is None:
+        return True
+    return any(n in written for n in range(block.start, block.end + 1))
+
+
+def join(pieces, written):
+    """Pieces a blank line split, joined where the change wrote both.
+
+    Splitting a new comment gains nothing, and an old one above it stays apart.
+    """
+    joined = None
+    for piece in pieces:
+        if joined and wrote(written, joined) and wrote(written, piece):
+            joined.end = piece.end
+            joined.text += " " + piece.text
+            continue
+        if joined:
+            yield joined
+        joined = piece
+    if joined:
+        yield joined
+
+
+def prose(path, lines):
+    """The words of a block comment, without its gutter.
+
+    Reading stops at a docblock's first tag: `@param`, `@return` and plugin
+    annotations are API detail Drupal asks for.
+    """
+    kept = []
+    for line in lines:
+        line = GUTTER.sub("", line.strip())
+        # A template's `@file` docblock is core's, copied along with the
+        # template it overrides, so there `@file` stops reading too.
+        if line.startswith("@file") and not path.endswith(".twig"):
+            line = line[len("@file"):]
+        elif line.startswith("@"):
+            break
+        kept.append(line)
+    return " ".join(kept)
+
+
+def code_blocks(path, lines, written=None):
+    """Comment blocks in a source file.
+
+    A blank line inside a run of comments starts a new piece; `join` decides
+    which pieces are one block.
+    """
+    line_tokens, block = syntax(path)
+    if line_tokens is None and block is None:
+        return
+    run, blank = [], False
+    inside, held, opened = False, [], 0
+    for number, raw in enumerate(lines, 1):
+        stripped = raw.strip()
+        if inside:
+            held.append(stripped)
+            if block[1] in stripped:
+                # What follows the closing token is code again.
+                held[-1] = held[-1].split(block[1])[0]
+                inside = False
+                yield Block(path, opened, number, prose(path, held), CODE_BUDGET)
+            continue
+        if block and stripped.startswith(block[0]):
+            rest = stripped[len(block[0]):]
+            if block[1] in rest:
+                text = prose(path, [rest.split(block[1])[0]])
+                yield Block(path, number, number, text, CODE_BUDGET)
+                continue
+            inside, held, opened = True, [rest], number
+            continue
+        token = next((t for t in line_tokens if stripped.startswith(t)), None)
+        if token and not stripped.startswith("#!"):
+            body = stripped[len(token):].strip()
+            if run and not blank:
+                run[-1].end = number
+                run[-1].text += " " + body
+            else:
+                run.append(Block(path, number, number, body, CODE_BUDGET))
+            blank = False
+        elif stripped:
+            yield from join(run, written)
+            run = []
+        elif run:
+            blank = True
+    yield from join(run, written)
+
+
+def docstrings(path, text):
+    """Python's docstrings, which carry the prose a `#` comment would."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return
+    documented = (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+    for node in ast.walk(tree):
+        if not isinstance(node, documented):
+            continue
+        body = ast.get_docstring(node)
+        if body:
+            first = node.body[0]
+            yield Block(path, first.lineno, first.end_lineno, body, CODE_BUDGET)
+
+
+def doc_blocks(path, lines):
+    """Paragraphs in a Markdown file.
+
+    A list item is its own paragraph. Fenced code, tables, headings and
+    indented code outside a list are not prose.
+    """
+    run, start, end = [], 0, 0
+    fence, in_list = None, False
+
+    def flush():
+        if run:
+            return Block(path, start, end, " ".join(run), DOC_BUDGET)
+        return None
+
+    for number, raw in enumerate(lines, 1):
+        stripped = raw.strip()
+        if fence:
+            if stripped.startswith(fence):
+                fence = None
+            continue
+        done = None
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            done, fence = flush(), stripped[:3]
+        elif not stripped:
+            done = flush()
+        elif stripped.startswith("#"):
+            done, in_list = flush(), False
+        elif stripped.startswith("|") or stripped.startswith("<"):
+            done = flush()
+        elif LIST_ITEM.match(stripped):
+            done, in_list = flush(), True
+            if done:
+                yield done
+            run, start, end = [LIST_ITEM.sub("", stripped)], number, number
+            continue
+        else:
+            indent = len(raw) - len(raw.lstrip())
+            if indent == 0:
+                in_list = False
+            if not run and indent >= 4 and not in_list:
+                continue
+            if not run:
+                start = number
+            run.append(re.sub(r"^>\s?", "", stripped))
+            end = number
+            continue
+        if done:
+            yield done
+        run = []
+    last = flush()
+    if last:
+        yield last
+
+
+def blocks_of(path, text, written=None):
+    """Every comment block in a file, whatever the file is written in."""
+    if any(fnmatch.fnmatch("/" + path, pattern) for pattern in SKIP):
+        return
+    if DDEV_GENERATED.search(text):
+        return
+    lines = text.splitlines()
+    if Path(path).suffix in DOC_SUFFIXES:
+        yield from doc_blocks(path, lines)
+        return
+    yield from code_blocks(path, lines, written)
+    if Path(path).suffix == ".py":
+        yield from docstrings(path, text)
+
+
+def added_lines(diff):
+    """The lines a diff adds, per file, read from its hunk headers."""
+    touched = {}
+    path = None
+    for line in diff.splitlines():
+        match = DIFF_FILE.match(line)
+        if match:
+            path = match.group(1)
+            touched.setdefault(path, set())
+            continue
+        hunk = HUNK.match(line)
+        if hunk and path:
+            first = int(hunk.group(1))
+            count = int(hunk.group(2) or 1)
+            touched[path].update(range(first, first + count))
+    return touched
+
+
+def git(*args):
+    return subprocess.run(
+        ("git", "-c", "core.quotepath=false") + args,
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def ls_files(*args):
+    return [path for path in git("ls-files", "-z", *args).split("\0") if path]
+
+
+def changed(base):
+    """What the working tree adds on top of its merge base with `base`."""
+    try:
+        point = git("merge-base", base, "HEAD").strip()
+    except subprocess.CalledProcessError:
+        point = base
+    # Pinned, so no one's diff config changes what `added_lines` reads.
+    diff = git(
+        "diff", "--unified=0", "--diff-filter=ACMR", "--no-color",
+        "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/", point,
+    )
+    touched = added_lines(diff)
+    # A file git has never seen is new whole. CI has none of these; someone
+    # running this before `git add` does.
+    for path in ls_files("--others", "--exclude-standard"):
+        touched[path] = range(1, sys.maxsize)
+    return touched
+
+
+def report(block):
+    """Print one block over budget, as a PR annotation too when CI is reading."""
+    print(
+        f"{block.path}:{block.start}: {block.words} words, "
+        f"budget {block.budget} — {' '.join(block.text.split())[:60]}…"
+    )
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(
+            f"::error file={block.path},line={block.start}::"
+            f"{block.words} words, budget {block.budget}. Shorten it."
+        )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--base", help="measure only what this ref does not have")
+    parser.add_argument("paths", nargs="*", help="files to read (default: all)")
+    args = parser.parse_args(argv)
+
+    # Git names paths from the repo root, so read them from there.
+    top = git("rev-parse", "--show-toplevel").strip()
+    explicit = [os.path.relpath(os.path.abspath(p), top) for p in args.paths]
+    os.chdir(top)
+
+    touched = changed(args.base) if args.base else None
+    if explicit:
+        paths = explicit
+    elif touched is not None:
+        paths = sorted(touched)
+    else:
+        paths = ls_files()
+
+    over = []
+    for path in paths:
+        # AGENTS.md links to CLAUDE.md, which is read under its own name.
+        if Path(path).is_symlink():
+            continue
+        try:
+            text = Path(path).read_text(encoding="utf-8")
+        except FileNotFoundError:
+            # Otherwise a mistyped path passes quietly.
+            print(f"{path}: no such file", file=sys.stderr)
+            continue
+        except (OSError, UnicodeDecodeError):
+            continue
+        written = None if touched is None else touched.get(path, ())
+        for block in blocks_of(path, text, written):
+            if block.words > block.budget and wrote(written, block):
+                over.append(block)
+
+    for block in sorted(over, key=lambda b: (b.path, b.start)):
+        report(block)
+    if over:
+        print(f"\n{len(over)} comment(s) over budget. Say it in fewer words.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci-scripts/tests/test_check_comments.py
+++ b/ci-scripts/tests/test_check_comments.py
@@ -1,0 +1,243 @@
+"""What the comment budget counts, and what it leaves alone."""
+
+import contextlib
+import io
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import check_comments as checker
+
+
+def words_at(path, text, line):
+    """The size of the block starting at `line`, or None if there is none."""
+    for block in checker.blocks_of(path, text):
+        if block.start == line:
+            return block.words
+    return None
+
+
+def sizes(path, text):
+    return [block.words for block in checker.blocks_of(path, text)]
+
+
+class CodeComments(unittest.TestCase):
+    def test_a_run_of_lines_is_one_block(self):
+        source = "// one two\n// three four\n$a = 1;\n"
+        self.assertEqual(sizes("a.php", source), [4])
+
+    def test_a_blank_line_keeps_the_block_open(self):
+        source = "# one two\n\n# three four\n"
+        self.assertEqual(sizes("a.sh", source), [4])
+
+    def test_a_blank_line_the_change_wrote_both_sides_of_keeps_it_open(self):
+        blocks = checker.blocks_of("a.sh", "# one two\n\n# three four\n", {1, 3})
+        self.assertEqual([block.words for block in blocks], [4])
+
+    def test_a_new_comment_under_an_old_one_is_its_own_block(self):
+        blocks = checker.blocks_of("a.sh", "# one two three\n\n# four\n", {3})
+        self.assertEqual([block.words for block in blocks], [3, 1])
+
+    def test_code_between_two_comments_splits_them(self):
+        source = "# one two\nrun\n# three four\n"
+        self.assertEqual(sizes("a.sh", source), [2, 2])
+
+    def test_a_shebang_is_not_a_comment(self):
+        self.assertEqual(sizes("a.sh", "#!/bin/sh\nrun\n"), [])
+
+    def test_a_php_attribute_is_not_a_comment(self):
+        self.assertEqual(sizes("a.php", "#[Hook('cron')]\n"), [])
+
+    def test_a_block_comment_is_read_whole(self):
+        source = "{# one two\nthree four\n#}\n<p></p>\n"
+        self.assertEqual(sizes("a.html.twig", source), [4])
+
+    def test_the_docblock_gutter_is_not_words(self):
+        self.assertEqual(sizes("a.php", "/**\n * one two\n */\n"), [2])
+
+    def test_a_docblock_is_read_up_to_its_first_tag(self):
+        source = (
+            "/**\n * one two\n *\n * @Block(\n *   id = \"three\",\n * )\n"
+            " *\n * @param int $four\n *   Five six.\n */\n"
+        )
+        self.assertEqual(sizes("a.php", source), [2])
+
+    def test_a_one_line_docblock_of_a_tag_has_no_words(self):
+        self.assertEqual(sizes("a.php", "/** @var \\Foo $one */\n"), [0])
+
+    def test_a_file_docblock_keeps_its_description(self):
+        source = "/**\n * @file\n * one two three\n */\n"
+        self.assertEqual(sizes("a.module", source), [3])
+
+    def test_a_template_file_docblock_is_not_read(self):
+        source = "{#\n/**\n * @file\n * one two\n */\n#}\n"
+        self.assertEqual(sizes("a.html.twig", source), [0])
+
+    def test_a_template_docblock_is_read_up_to_its_first_tag(self):
+        source = "{#\n/**\n * one two\n *\n * @see three()\n */\n#}\n"
+        self.assertEqual(sizes("a.html.twig", source), [2])
+
+    def test_a_trailing_comment_is_not_read(self):
+        self.assertEqual(sizes("a.php", "$a = 1; // one two three\n"), [])
+
+    def test_a_python_docstring_counts(self):
+        self.assertEqual(sizes("a.py", '"""one two three"""\n'), [3])
+
+    def test_an_unknown_file_type_has_no_comments(self):
+        self.assertEqual(sizes("a.docx", "# one two\n"), [])
+
+    def test_a_skipped_file_is_not_read(self):
+        source = "// one two\n"
+        path = "web/sites/default/default.settings.php"
+        self.assertEqual(sizes(path, source), [])
+
+    def test_a_file_ddev_generates_is_not_read(self):
+        source = "#ddev-generated\n# one two\n"
+        self.assertEqual(sizes(".ddev/docker-compose.solr.yaml", source), [])
+
+    def test_mentioning_the_ddev_marker_does_not_skip_a_file(self):
+        source = "echo '#ddev-generated'\n# one two\n"
+        self.assertEqual(sizes("a.sh", source), [2])
+
+
+class DocParagraphs(unittest.TestCase):
+    def test_a_paragraph_is_a_block(self):
+        self.assertEqual(sizes("a.md", "one two three\nfour five\n"), [5])
+
+    def test_a_blank_line_ends_a_paragraph(self):
+        self.assertEqual(sizes("a.md", "one two\n\nthree four five\n"), [2, 3])
+
+    def test_a_list_item_is_its_own_paragraph(self):
+        source = "- one two\n- three four five\n"
+        self.assertEqual(sizes("a.md", source), [2, 3])
+
+    def test_a_list_item_keeps_its_continuation(self):
+        source = "- one two\n  three four\n"
+        self.assertEqual(sizes("a.md", source), [4])
+
+    def test_fenced_code_is_not_prose(self):
+        source = "one two\n\n```\nddev phpcs  # three four\n```\n"
+        self.assertEqual(sizes("a.md", source), [2])
+
+    def test_headings_and_tables_are_not_prose(self):
+        source = "## one two three\n\n| four | five |\n"
+        self.assertEqual(sizes("a.md", source), [])
+
+    def test_an_indented_code_block_is_not_prose(self):
+        source = "## Running things\n\n    ddev phpcs one two\n"
+        self.assertEqual(sizes("a.md", source), [])
+
+    def test_an_indented_line_under_a_list_is_prose(self):
+        source = "- one two\n\n    three four five\n"
+        self.assertEqual(words_at("a.md", source, 3), 3)
+
+    def test_a_doc_gets_the_larger_budget(self):
+        blocks = list(checker.blocks_of("a.md", "one two\n"))
+        self.assertEqual(blocks[0].budget, checker.DOC_BUDGET)
+        self.assertGreater(checker.DOC_BUDGET, checker.CODE_BUDGET)
+
+
+class ChangedLines(unittest.TestCase):
+    def test_hunk_headers_name_the_added_lines(self):
+        diff = (
+            "diff --git a/x.php b/x.php\n"
+            "--- a/x.php\n"
+            "+++ b/x.php\n"
+            "@@ -3,0 +4,2 @@\n"
+            "+// one\n"
+            "+// two\n"
+        )
+        self.assertEqual(checker.added_lines(diff), {"x.php": {4, 5}})
+
+    def test_a_hunk_without_a_count_adds_one_line(self):
+        diff = "+++ b/x.php\n@@ -3 +3 @@\n"
+        self.assertEqual(checker.added_lines(diff), {"x.php": {3}})
+
+    def test_a_deletion_adds_nothing(self):
+        diff = "+++ b/x.php\n@@ -3,2 +2,0 @@\n"
+        self.assertEqual(checker.added_lines(diff), {"x.php": set()})
+
+    def test_a_path_with_a_space_loses_the_tab_git_ends_it_with(self):
+        diff = "+++ b/a b.php\t\n@@ -3 +3 @@\n"
+        self.assertEqual(checker.added_lines(diff), {"a b.php": {3}})
+
+
+class AgainstGit(unittest.TestCase):
+    """The whole checker, run the way CI and a developer run it."""
+
+    LONG = "# " + " ".join(["word"] * 40) + "\n"
+
+    def setUp(self):
+        scratch = tempfile.TemporaryDirectory()
+        self.addCleanup(scratch.cleanup)
+        self.addCleanup(os.chdir, os.getcwd())
+        self.repo = Path(scratch.name)
+        (self.repo / "sub").mkdir()
+        self.git("init", "-q")
+        self.commit({"sub/a.sh": "run\n", "sub/a b.sh": "run\n"})
+
+    def git(self, *args):
+        subprocess.run(
+            ("git", "-c", "user.name=t", "-c", "user.email=t@t",
+             "-c", "commit.gpgsign=false") + args,
+            cwd=self.repo, check=True, capture_output=True,
+        )
+
+    def commit(self, files):
+        for name, text in files.items():
+            (self.repo / name).write_text(text)
+        self.git("add", ".")
+        self.git("commit", "-q", "--no-verify", "-m", "base")
+
+    def check(self, where="."):
+        os.chdir(self.repo / where)
+        with contextlib.redirect_stdout(io.StringIO()):
+            return checker.main(["--base", "HEAD"])
+
+    def test_a_long_comment_in_a_changed_file_is_over(self):
+        (self.repo / "sub/a.sh").write_text("run\n" + self.LONG)
+        self.assertEqual(self.check(), 1)
+
+    def test_a_file_git_has_never_seen_is_new_whole(self):
+        (self.repo / "sub/new file.sh").write_text(self.LONG)
+        self.assertEqual(self.check(), 1)
+
+    def test_a_space_in_a_changed_file_name_is_read(self):
+        (self.repo / "sub/a b.sh").write_text("run\n" + self.LONG)
+        self.assertEqual(self.check(), 1)
+
+    def test_a_subdirectory_reads_what_the_root_does(self):
+        (self.repo / "sub/a.sh").write_text("run\n" + self.LONG)
+        self.assertEqual(self.check("sub"), 1)
+
+    def test_diff_config_does_not_change_what_is_read(self):
+        (self.repo / "sub/a.sh").write_text("run\n" + self.LONG)
+        for key, value in (
+            ("diff.mnemonicPrefix", "true"),
+            ("diff.noprefix", "true"),
+            ("color.diff", "always"),
+        ):
+            config = {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": key,
+                "GIT_CONFIG_VALUE_0": value,
+            }
+            with self.subTest(key), mock.patch.dict(os.environ, config):
+                self.assertEqual(self.check(), 1)
+
+    def test_a_short_comment_under_an_old_long_one_passes(self):
+        self.commit({"sub/a.sh": self.LONG + "run\n"})
+        (self.repo / "sub/a.sh").write_text(self.LONG + "\n# new\nrun\n")
+        self.assertEqual(self.check(), 0)
+
+    def test_a_new_symlink_to_an_old_long_comment_passes(self):
+        self.commit({"sub/a.sh": self.LONG})
+        (self.repo / "sub/link.sh").symlink_to("a.sh")
+        self.assertEqual(self.check(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a CI job that fails when a pull request adds a comment over 30 words (or a Markdown paragraph over 60), measuring only the blocks it touches so existing long comments are left alone. Docblocks count up to their first tag, and core scaffold files, DDEV-generated add-on files and the `AGENTS.md` symlink are skipped. Replayed over the last 20 merges to `main`, it flagged only the long docblocks in recent feature PRs and nothing in dependency bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmzyYYgLMdGD7zZvqFHiyX